### PR TITLE
fix: only export a locale that is actually generated

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,15 +1,22 @@
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:/usr/local/bin:$PATH
-export LANG=ja_JP.UTF-8
-export LC_ALL=ja_JP.UTF-8
 
 # set vim motion
 set -o vi
 
 # Force a UTF-8 locale so multibyte (e.g. Japanese) renders over SSH clients
 # like Termius, which don't forward the locale Terminal.app sets locally.
-export LANG=en_US.UTF-8
-export LC_ALL=en_US.UTF-8
+# Only export a locale that's actually generated -- stock WSL/container images
+# ship C.UTF-8 only, and an unavailable value makes bash warn on every start:
+#   bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+for _l in en_US.UTF-8 C.UTF-8; do
+    if locale -a 2>/dev/null | grep -qiE "^${_l%.*}\.(utf-?8)$"; then
+        export LANG="$_l"
+        export LC_ALL="$_l"
+        break
+    fi
+done
+unset _l
 
 # Uncomment the following line to profile zsh
 # zmodload zsh/zprof


### PR DESCRIPTION
## Problem

`.zshrc` unconditionally exported `LC_ALL=en_US.UTF-8`, but stock WSL and container images only generate `C.UTF-8`. Every `bash` inherits the unavailable value and warns on start:

```
bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```

## Fix

Export the first locale that `locale -a` actually reports, preferring `en_US.UTF-8` and falling back to `C.UTF-8`. Machines with the real locale generated are unaffected.

Also drops the `ja_JP.UTF-8` exports from lines 3-4 — dead code, immediately overwritten by the `en_US` exports below them, and that locale isn't generated either.

## Testing

On Ubuntu 24.04 WSL:

- `zsh -n .zshrc` passes (the check `lint.yml` runs)
- The loop resolves to `C.UTF-8`
- `bash` starts without the warning
- Multibyte still decodes correctly (`日本語` → 3 chars, not bytes)

## Tradeoff

`C.UTF-8` sorts by codepoint rather than locale rules, so `sort`/`ls` ordering differs slightly from `en_US` on machines that fall back. Running `sudo locale-gen en_US.UTF-8 && sudo update-locale` makes the loop pick the real locale up automatically on the next shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)