### PR TITLE
Add tmux-fzf plugin with function key bindings

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -36,6 +36,16 @@ set-option default-terminal "screen-256color"
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'catppuccin/tmux'
 set -g @plugin 'christoomey/vim-tmux-navigator'
+# requires fzf to be installed
+set -g @plugin 'sainnhe/tmux-fzf'
+
+# tmux-fzf をワンタップで
+bind -n F1 run-shell -b "~/.tmux/plugins/tmux-fzf/main.sh"
+
+# よく使う操作も prefix なしに
+bind -n F2 previous-window
+bind -n F3 next-window
+bind -n F4 choose-tree -Zw
 
 set -g @catppuccin_window_left_separator " █"
 set -g @catppuccin_window_right_separator "█ "


### PR DESCRIPTION
## Summary
Add the `tmux-fzf` plugin to enhance tmux navigation and window management with fuzzy finding capabilities, along with convenient function key bindings for quick access to common operations.

## Changes
- Added `sainnhe/tmux-fzf` plugin to the tmux plugin list (requires fzf to be installed)
- Bound `F1` to open tmux-fzf main menu without requiring the tmux prefix
- Bound `F2` to switch to previous window
- Bound `F3` to switch to next window
- Bound `F4` to open the window tree selector

These bindings use `-n` flag to work without the tmux prefix key, providing quick access to frequently used operations.

https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic