### PR TITLE
feat(tmux): bind F1 to pmux popup instead of tmux-fzf

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -36,11 +36,10 @@ set-option default-terminal "screen-256color"
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'catppuccin/tmux'
 set -g @plugin 'christoomey/vim-tmux-navigator'
-# requires fzf to be installed
-set -g @plugin 'sainnhe/tmux-fzf'
 
-# tmux-fzf をワンタップで
-bind -n F1 run-shell -b "~/.tmux/plugins/tmux-fzf/main.sh"
+# pmux (ghq + fzf でセッション選択) をワンタップで
+# 対話的な選択が必要なので run-shell ではなく popup で実行する
+bind -n F1 display-popup -E -w 80% -h 80% "~/.scripts/pmux"
 
 # よく使う操作も prefix なしに
 bind -n F2 previous-window


### PR DESCRIPTION
Follow-up to #230.

F1 で tmux-fzf を起動する代わりに、リポジトリ内の自前スクリプト `.scripts/pmux` を実行するように変更します。

## 変更内容

- `bind -n F1` を `display-popup -E -w 80% -h 80% "~/.scripts/pmux"` に変更
- 不要になった `set -g @plugin 'sainnhe/tmux-fzf'` を削除
- F2 / F3 / F4 のバインドは #230 のまま変更なし

## `run-shell` ではなく `display-popup` を使う理由

`pmux` は中で `fzf` を対話的に呼ぶため TTY が必要です。`run-shell` には TTY がないので、何も表示されないまま終了してしまいます。`display-popup -E` なら TTY があり、`pmux` 末尾の `tmux switch-client` も popup 内では `$TMUX` が設定されているため正しい分岐に入り、選択後に popup が閉じてセッションが切り替わります。

`display-popup` は tmux 3.2 以降が必要です。

## 動作確認

- `tmux -f .tmux.conf new-session -d` で設定がパースエラーなく読み込まれることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_