### PR TITLE
feat(tmux): replace F4 choose-tree with a fuzzy window switcher

### DIFF
--- a/.scripts/tmux-window-fzf
+++ b/.scripts/tmux-window-fzf
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Fuzzy-select a tmux window across all sessions and switch to it.
+# Bound to F4 in .tmux.conf, launched through display-popup so fzf gets a tty.
+
+set -euo pipefail
+
+# Columns are aligned with tmux's own #{pN:...} padding so that no external
+# `column` is needed. The target is the first field, kept free of the active
+# marker so it can be handed to tmux verbatim.
+format='#{p24:#{session_name}:#{window_index}} #{?window_active,*, } #{p20:#{window_name}} #{pane_current_command}'
+
+selected=$(
+  tmux list-windows -a -F "$format" |
+    fzf --reverse \
+      --prompt='window> ' \
+      --preview 'tmux capture-pane -ep -t {1}' \
+      --preview-window=down:60%
+) || exit 0
+
+if [[ -z $selected ]]; then
+  exit 0
+fi
+
+target=$(awk '{print $1}' <<<"$selected")
+
+tmux switch-client -t "${target%%:*}"
+tmux select-window -t "$target"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -44,7 +44,9 @@ bind -n F1 display-popup -E -w 80% -h 80% "~/.scripts/pmux"
 # よく使う操作も prefix なしに
 bind -n F2 previous-window
 bind -n F3 next-window
-bind -n F4 choose-tree -Zw
+
+# 全セッションのウィンドウを fuzzy search して切り替える (choose-tree の代替)
+bind -n F4 display-popup -E -w 80% -h 80% "~/.scripts/tmux-window-fzf"
 
 set -g @catppuccin_window_left_separator " █"
 set -g @catppuccin_window_right_separator "█ "


### PR DESCRIPTION
Follow-up to #231.

F4 の `choose-tree -Zw` を、全セッションのウィンドウを fzf で絞り込んで切り替えるスクリプトに置き換えます。Termius など、ファンクションキーだけで操作したい環境を想定しています。

## 変更内容

- `.scripts/tmux-window-fzf` を追加（全セッションのウィンドウ一覧 → fzf で選択 → プレビュー付きで切り替え）
- `bind -n F4` を `display-popup -E -w 80% -h 80% "~/.scripts/tmux-window-fzf"` に変更
- F1 / F2 / F3 は変更なし

`.scripts` は `$HOME` にディレクトリごと symlink されているので、`make` の再実行は不要です。

## 実装メモ

叩き台の案から、実際に tmux 3.4 で動かして見つかった問題を修正しています。

1. **`\t` が展開されない** — tmux の `-F` はバックスラッシュエスケープを解釈しないため、出力は `server\tbash` というリテラル文字列になります。結果として `column -t -s $'\t'` は整形されず、一覧に `\t` がそのまま出ます。
2. **`column` 依存を削除** — 代わりに tmux 標準の `#{p24:...}`（左寄せパディング）で整形。util-linux が入っていない環境でも動きます。
3. **アクティブウィンドウでプレビューが壊れる** — `*` を ID に直結させると、プレビュー側に `alpha:1*` という不正な target が渡ります。`*` を第 1 フィールドから分離し、プレビューには fzf の `{1}` を使います。
4. **切り替えを 2 コマンドに分割** — `switch-client` でセッションを移り、`select-window` でウィンドウを明示的に選びます。
5. **キャンセル時の異常終了** — fzf を Esc で閉じると `set -e` でそのまま落ちるため `|| exit 0` を追加。

## 動作確認

- アクティブ / 非アクティブ、長いセッション名を含む全ウィンドウで、target のパース・`capture-pane`・`select-window` が成功することを確認
- `tmux -f .tmux.conf new-session -d` が警告なく読み込まれ、`list-keys -T root` に F1〜F4 が期待どおり登録されることを確認
- fzf 自体は検証環境に無いため、対話部分は未実行です

## 前提

- `display-popup` は tmux 3.2 以降が必要です
- F4 が効かない場合、Termius 側でファンクションキーがアプリに取られていないか確認してください

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_