### PR TITLE
feat(tmux): bind F5 to new-window

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -48,6 +48,9 @@ bind -n F3 next-window
 # 全セッションのウィンドウを fuzzy search して切り替える (choose-tree の代替)
 bind -n F4 display-popup -E -w 80% -h 80% "~/.scripts/tmux-window-fzf"
 
+# 新しいウィンドウを作成 (prefix c と同じ)
+bind -n F5 new-window
+
 set -g @catppuccin_window_left_separator " █"
 set -g @catppuccin_window_right_separator "█ "
 set -g @catppuccin_window_middle_separator " █"


### PR DESCRIPTION
## Summary
- Add a prefix-less `F5` bind that creates a new window, same as `prefix c`
- Follows the existing function-key binds (F1: pmux popup, F2/F3: prev/next window, F4: fuzzy window switcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)