### PR TITLE
feat(tmux): bind prefix + w to the fuzzy window switcher

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -46,7 +46,9 @@ bind -n F2 previous-window
 bind -n F3 next-window
 
 # 全セッションのウィンドウを fuzzy search して切り替える (choose-tree の代替)
+# prefix + w も同じものに差し替える (既定は choose-tree -Zw)
 bind -n F4 display-popup -E -w 80% -h 80% "~/.scripts/tmux-window-fzf"
+bind w display-popup -E -w 80% -h 80% "~/.scripts/tmux-window-fzf"
 
 # 新しいウィンドウを作成 (prefix c と同じ)
 bind -n F5 new-window


### PR DESCRIPTION
Follow-up to #232.

`prefix + w` の既定の `choose-tree -Zw` を、F4 と同じ `.scripts/tmux-window-fzf` の popup に差し替えます。両方の入り口で挙動が揃います。

## 変更内容

- `bind w display-popup -E -w 80% -h 80% "~/.scripts/tmux-window-fzf"` を追加
- F1〜F5 は変更なし

## 動作確認

- `list-keys -T prefix` で、既定の `choose-tree -Zw` が重複ではなく上書きされていることを確認
- `tmux -f .tmux.conf new-session -d` が警告なく読み込まれ、F1〜F5 も従来どおり登録されることを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_