### PR TITLE
ci: update actions/checkout to v4 and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install zsh
         run: sudo apt-get update; sudo apt-get install zsh
       - name: Check Zshrc Syntax

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Run Make
         run: make


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from the deprecated `@v1` (make.yml) and `@v2` (lint.yml) to `@v4` — the old versions run on EOL Node runtimes
- Add `.github/dependabot.yml` with monthly `github-actions` updates so action versions stay current automatically

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)