### PR TITLE
feat(tmux): auto-install TPM if missing

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -29,10 +29,7 @@ bind -T copy-mode-vi v send-keys -X begin-selection
 
 set-option -g status-position top
 set-option default-terminal "screen-256color"
-# Prerequisites for plugins
-# git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
-# use <leader> + I to install plugins
-# Plugins
+# Plugins (TPM は未導入なら自動で clone される / <prefix> + I で追加インストール)
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'catppuccin/tmux'
 set -g @plugin 'christoomey/vim-tmux-navigator'
@@ -72,6 +69,9 @@ set -g @catppuccin_status_fill "icon"
 set -g @catppuccin_status_connect_separator "no"
 
 set -g @catppuccin_directory_text "#{b:pane_current_path}"
+# TPM がなければ clone してプラグインもまとめて導入する
+if "test ! -d ~/.tmux/plugins/tpm" \
+  "run 'git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm && ~/.tmux/plugins/tpm/bin/install_plugins'"
 run '~/.tmux/plugins/tpm/tpm'
 
 # Override catppuccin pane settings to show titles


### PR DESCRIPTION
## Summary
- Add TPM's documented auto-install guard before `run '~/.tmux/plugins/tpm/tpm'`: if `~/.tmux/plugins/tpm` doesn't exist, clone it and run `install_plugins`, so tmux self-bootstraps on a fresh machine
- Replace the stale "Prerequisites" comment that told you to clone TPM manually

## Test plan
- Loaded the config on an isolated tmux server (`tmux -L conftest`) with TPM present — loads cleanly, no regression
- Loaded it with a scratch $HOME without TPM — TPM was auto-cloned and `install_plugins` picked up all three plugins from the config

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)