### PR TITLE
docs: document .scripts/ in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ Run `bootstrap.ps1` to setup configuration for PowerShell
 ./bootstrap.ps1
 ```
 
+## Scripts
+
+`.scripts/` is symlinked into `$HOME` by `make` and added to `PATH` by `.zshrc`.
+
+| Script | Description |
+| --- | --- |
+| `pmux` | Pick a ghq-managed repo via fzf (with README preview) and open/attach a tmux session for it. Bound to `F1` in tmux. |
+| `tmux-window-fzf` | Fuzzy-select a tmux window across all sessions (with pane preview) and switch to it. Bound to `F4` and `prefix + w` in tmux. |
+| `tmux-send-all` | Send a command to tmux panes in the current session, targeting (`-t`) or excluding (`-i`) specific panes. |
+| `tmux-cleanup-windows.sh` | Close all tmux windows except the active one and windows 0–2. |
+| `tmux-pane-name` | Rename the current tmux window to the current git branch (or a given name). |
+| `tmux-pane-highlight` | Set a colored border + status emoji on the current pane/window; used to signal Claude Code state from hooks. `off` clears it. |
+| `tssh` | List Tailscale hosts and ssh into the selected one (fzf picker, `tailscale ssh` for Linux targets, plain ssh otherwise). See `tssh -h`. |
+| `switch-worktree` | Pick a git worktree via fzf and cd into it. Sourced via the `Ctrl+B` keybind in zsh. |
+| `git-worktree-pull` | Fix the fetch refspec of a bare/worktree clone so `git fetch origin` gets all remote branches. Aliased as `gwp`. |
+| `killport` | Kill the processes listening on a given port (`killport 8080`). |
+| `duck` / `google` | Search DuckDuckGo / Google from the terminal via lynx. |
+| `urlencode` | URL-encode arguments or stdin; used by `duck` and `google`. |
+
 ## Environment Variables
 
 To configure your secrets API key securely, create a credentials file outside version control:


### PR DESCRIPTION
## Summary
Add a `## Scripts` section to the README with a table describing every tool in `.scripts/` — what it does and, where relevant, its tmux/zsh binding (`pmux` → F1, `tmux-window-fzf` → F4 / `prefix + w`, `switch-worktree` → `Ctrl+B`, `git-worktree-pull` → `gwp`).

Descriptions were written from reading each script's source.

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)