### PR TITLE
ci: lint .scripts with shellcheck and workflows with actionlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,21 @@ jobs:
         run: zsh -n ./.zshrc
       - name: Check Zshrc Commands
         run: zsh -c "source ./.zshrc"
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run shellcheck on .scripts
+        run: shellcheck .scripts/*
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color

--- a/.scripts/google
+++ b/.scripts/google
@@ -1,4 +1,4 @@
 #!/bin/sh
 # ref: https://github.com/rwxrob/dot
 url="https://google.com/search?q=$(urlencode "$*")"
-exec lynx -vikeys $url
+exec lynx -vikeys "$url"

--- a/.scripts/killport
+++ b/.scripts/killport
@@ -18,7 +18,7 @@ if ! [[ "$port" =~ ^[0-9]+$ ]]; then
 fi
 
 # Find processes using the port
-processes=$(lsof -ti:$port 2>/dev/null)
+processes=$(lsof -ti:"$port" 2>/dev/null)
 
 if [ -z "$processes" ]; then
     echo "No processes found running on port $port"
@@ -27,7 +27,7 @@ fi
 
 echo "Killing processes on port $port:"
 echo "$processes" | while read -r pid; do
-    if ps -p $pid > /dev/null 2>&1; then
+    if ps -p "$pid" > /dev/null 2>&1; then
         echo "  PID $pid"
     fi
 done

--- a/.scripts/pmux
+++ b/.scripts/pmux
@@ -16,17 +16,17 @@ selected_name=$(basename "$selected" | tr . _)
 tmux_running=$(pgrep tmux)
 
 if [[ -z $TMUX ]] && [[ -z $tmux_running ]]; then
-  tmux new-session -s $selected_name -c $selected
+  tmux new-session -s "$selected_name" -c "$selected"
   exit 0
 fi
 
-if ! tmux has-session -t $selected_name 2>/dev/null; then
-  tmux new-session -ds $selected_name -c $selected
+if ! tmux has-session -t "$selected_name" 2>/dev/null; then
+  tmux new-session -ds "$selected_name" -c "$selected"
 fi
 
 if [[ -z $TMUX ]]; then
-  tmux attach-session -t $selected_name
+  tmux attach-session -t "$selected_name"
   exit 0
 fi
 
-tmux switch-client -t $selected_name
+tmux switch-client -t "$selected_name"

--- a/.scripts/switch-worktree
+++ b/.scripts/switch-worktree
@@ -7,7 +7,7 @@ paths_file=$(mktemp)
 # Process git worktree list
 git worktree list | sed '1d' | awk '{
     # Store the full path
-    print $1 > "'$paths_file'";
+    print $1 > "'"$paths_file"'";
     
     # Extract branch name
     branch = $3;
@@ -32,18 +32,20 @@ git worktree list | sed '1d' | awk '{
     
     # Format the output with repo/worktree names
     printf "%-30s %s\n", repo_name "/" worktree_name, branch_display;
-}' > $worktree_path
+}' > "$worktree_path"
 
 # Use fzf for selection and get the selected line number
-selected_line=$(cat $worktree_path | nl -w1 -s: | fzf --layout=reverse --prompt="Select worktree: " \
+# shellcheck disable=SC2016  # the preview command must reach fzf unexpanded
+selected_line=$(nl -w1 -s: < "$worktree_path" | fzf --layout=reverse --prompt="Select worktree: " \
   --preview 'echo -e "Currently working on: \n\n$(echo {} | cut -d" " -f2-)"' | cut -d: -f1)
 
 # Get the path from the corresponding line in the paths file
 selected_path=$(sed "${selected_line}q;d" "$paths_file")
 
 # Clean up temporary files
-rm $worktree_path
-rm $paths_file
+rm "$worktree_path"
+rm "$paths_file"
 
 # Change to the selected directory
-cd "$selected_path"
+# This script is sourced (Ctrl+B keybind in .zshrc), so return rather than exit
+cd "$selected_path" || return

--- a/.scripts/tmux-send-all
+++ b/.scripts/tmux-send-all
@@ -108,8 +108,11 @@ main() {
         exit 1
     fi
     
-    # Get all pane indices
-    local all_panes=($(tmux list-panes -F '#{pane_index}' 2>/dev/null))
+    # Get all pane indices (no mapfile: macOS /bin/bash is 3.2)
+    local all_panes=()
+    while IFS= read -r pane_index; do
+        all_panes+=("$pane_index")
+    done < <(tmux list-panes -F '#{pane_index}' 2>/dev/null)
     
     if [[ ${#all_panes[@]} -eq 0 ]]; then
         echo "Error: No panes found"


### PR DESCRIPTION
## Summary
- Add a `shellcheck` CI job that lints everything in `.scripts/` at default severity (shellcheck is preinstalled on ubuntu runners)
- Add an `actionlint` CI job for the workflow files, using actionlint's official download script
- Fix all 16 existing shellcheck findings so the job starts green:
  - Quote variables in `google`, `killport`, `pmux`, `switch-worktree` (SC2086)
  - `switch-worktree`: guard the final `cd` with `|| return` (SC2164) — `return` not `exit`, because the script is sourced via the `Ctrl+B` keybind and `exit` would kill the shell
  - `tmux-send-all`: build the pane array with a `read` loop instead of unquoted command-substitution expansion (SC2207); `mapfile` was avoided since macOS `/bin/bash` is 3.2
  - Suppress SC2016 on the fzf `--preview` string, which is intentionally unexpanded

## Test plan
- `shellcheck .scripts/*` and `actionlint` both pass locally
- `bash -n` / `sh -n` on all edited scripts
- Smoke-tested `killport` (usage, invalid port, no-process paths)

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)