### PR TITLE
chore: add secrets template and gitleaks CI guard

### DIFF
--- a/.config/secrets/credentials.sh.example
+++ b/.config/secrets/credentials.sh.example
@@ -1,0 +1,11 @@
+# Template for the secret credentials file loaded by .zshrc / .bashrc.
+# Copy this next to itself and fill in real values:
+#
+#   cp credentials.sh.example credentials.sh
+#   chmod 600 credentials.sh
+#
+# credentials.sh is gitignored (.config/secrets/.gitignore) — never commit it.
+
+export OPENAI_API_KEY=""
+export ANTHROPIC_API_KEY=""
+export GITHUB_PAT=""

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,3 +35,15 @@ jobs:
         run: |
           bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
+
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ chmod 600 ~/.config/secrets/credentials.sh
 ```
 
 This file is ignored by git via `.config/secrets/.gitignore`, so your key stays private, and your shell configs (`.bashrc`, `.zshrc`) will automatically load it.
+
+A template listing the expected variables is committed at `.config/secrets/credentials.sh.example` — copy it to `credentials.sh` and fill in the values. CI runs [gitleaks](https://github.com/gitleaks/gitleaks) to catch secrets accidentally committed to the repo.


### PR DESCRIPTION
## Summary
- Commit `.config/secrets/credentials.sh.example` listing the variables the shell configs expect (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_PAT`) with copy instructions; the real `credentials.sh` remains gitignored
- Add a `gitleaks` CI job (`gitleaks/gitleaks-action@v2`, full-history checkout) to catch secrets accidentally committed to the repo
- Point the README's Environment Variables section at the template

## Test plan
- Ran `gitleaks git .` locally over all 440 commits — history is clean, so the CI job starts green
- `actionlint` passes on the updated workflow
- Verified the real `credentials.sh` is not tracked and the `.example` file is not caught by `.config/secrets/.gitignore`

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)