### PR TITLE
feat(tmux): bind F6 to a keybind cheat-sheet popup

### DIFF
--- a/.scripts/tmux-cheatsheet
+++ b/.scripts/tmux-cheatsheet
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# tmux-cheatsheet: show the prefix-less (root table) keybinds in a popup.
+# Generated from `tmux list-keys`, so new binds show up automatically.
+# Bound to F6 in .tmux.conf via display-popup; mouse bindings are skipped.
+
+set -euo pipefail
+
+printf 'Prefix-less keybinds\n'
+printf '====================\n\n'
+
+tmux list-keys -T root |
+  awk '$4 !~ /Mouse|Wheel|Click|Drag/ {
+    cmd = ""
+    for (i = 5; i <= NF; i++) cmd = cmd (i > 5 ? " " : "") $i
+    if (length(cmd) > 68) cmd = substr(cmd, 1, 65) "..."
+    printf "%-8s %s\n", $4, cmd
+  }'
+
+printf '\n(press any key to close)'
+read -rsn1 || true

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -50,6 +50,9 @@ bind w display-popup -E -w 80% -h 80% "~/.scripts/tmux-window-fzf"
 # 新しいウィンドウを作成 (prefix c と同じ)
 bind -n F5 new-window
 
+# prefix なしキーバインドの一覧をポップアップ表示 (チートシート)
+bind -n F6 display-popup -E -w 80% -h 60% "~/.scripts/tmux-cheatsheet"
+
 set -g @catppuccin_window_left_separator " █"
 set -g @catppuccin_window_right_separator "█ "
 set -g @catppuccin_window_middle_separator " █"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Run `bootstrap.ps1` to setup configuration for PowerShell
 | --- | --- |
 | `pmux` | Pick a ghq-managed repo via fzf (with README preview) and open/attach a tmux session for it. Bound to `F1` in tmux. |
 | `tmux-window-fzf` | Fuzzy-select a tmux window across all sessions (with pane preview) and switch to it. Bound to `F4` and `prefix + w` in tmux. |
+| `tmux-cheatsheet` | Show the prefix-less keybinds in a popup, generated from `tmux list-keys`. Bound to `F6` in tmux. |
 | `tmux-send-all` | Send a command to tmux panes in the current session, targeting (`-t`) or excluding (`-i`) specific panes. |
 | `tmux-cleanup-windows.sh` | Close all tmux windows except the active one and windows 0–2. |
 | `tmux-pane-name` | Rename the current tmux window to the current git branch (or a given name). |


### PR DESCRIPTION
## Summary
- Add `.scripts/tmux-cheatsheet`: formats `tmux list-keys -T root` into a readable list (mouse bindings filtered out, long commands truncated), so new prefix-less binds appear automatically without maintaining a static list
- Bind `F6` to show it via `display-popup`; any key closes it
- Add the script to the README table

## Test plan
- `shellcheck` clean
- Verified the formatted output lists F1–F5, `C-]`, and the vim-tmux-navigator binds
- Loaded the config on an isolated tmux server and confirmed the F6 bind registers

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)