### PR TITLE
feat: add one-command bootstrap script for new machines

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run shellcheck on .scripts
-        run: shellcheck .scripts/*
+        run: shellcheck .scripts/* install.sh
 
   actionlint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VSCODE_SCRIPT_PATH := $(abspath configs/.vscode)
 CONFIG_PATH := $(wildcard .config/??*)
 .DEFAULT_GOAL	:= dotfiles
 
-.PHONY: list dotfiles config unlink brew vscodeExtensions help
+.PHONY: list dotfiles config unlink brew bootstrap vscodeExtensions help
 
 list: # Show dotfiles in this repository
 	@echo 'list - Showing list of dotfiles in this repository'
@@ -31,6 +31,9 @@ unlink: # Remove dotfile symlinks from home directory
 	@echo '------------------------'
 	@$(foreach val, $(TARGET) $(CONFIG_PATH), if [ -L "$(HOME)/$(val)" ]; then rm -v "$(HOME)/$(val)"; fi;)
 	@echo '------------------------'
+
+bootstrap: # Full new-machine setup (Homebrew, packages, symlinks, asdf runtimes)
+	@./install.sh
 
 brew: # Install Homebrew packages from Brewfile
 	@echo 'brew - Installing Homebrew packages from Brewfile'

--- a/README.md
+++ b/README.md
@@ -11,17 +11,24 @@
 
 Easily set dotfiles using `Makefile`
 
-![makefile](https://user-images.githubusercontent.com/6936373/63206028-6458d600-c0e8-11e9-8f6f-64ad969c5280.png)
-
 [mainworkflowbadge]: https://github.com/Naturalclar/dotfiles/workflows/Main%20workflow/badge.svg
 [githubactions]: https://github.com/Naturalclar/dotfiles/actions
 
 ## Mac or Linux
 
-Run `make` to automatically set all dotfiles to `$HOME`
+One-command setup for a new machine:
 
 ```
-make
+git clone https://github.com/Naturalclar/dotfiles.git && cd dotfiles && ./install.sh
+```
+
+`install.sh` (also available as `make bootstrap`) is idempotent and safe to re-run. It installs Homebrew and the Brewfile packages (macOS), initializes the zsh-plugin submodules, symlinks all dotfiles, installs asdf plus the runtimes in `.tool-versions`, and applies the macOS key-repeat settings.
+
+For just the symlinks:
+
+```
+make            # symlink dotfiles into $HOME
+make config     # symlink .config entries
 ```
 
 ## Windows

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# install.sh — one-command setup for a new machine (macOS / Linux).
+#
+#   git clone https://github.com/Naturalclar/dotfiles.git && cd dotfiles && ./install.sh
+#
+# Idempotent: every step checks before acting, so re-running is safe.
+# Windows uses bootstrap.ps1 instead.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ASDF_VERSION="v0.13.1" # keep in sync with the version .zshrc expects
+
+log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
+
+# --- Homebrew (macOS) --------------------------------------------------------
+if [ "$(uname)" = "Darwin" ]; then
+  if ! command -v brew >/dev/null 2>&1; then
+    log "Installing Homebrew"
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /usr/local/bin/brew shellenv)"
+  fi
+
+  # Third-party taps must be tapped and trusted before `brew bundle` can
+  # install from them non-interactively (`brew trust` is a no-op on older brew).
+  log "Tapping and trusting third-party taps"
+  awk -F'"' '/^tap /{print $2}' "$REPO_DIR/Brewfile" | while read -r tap; do
+    brew tap "$tap" >/dev/null 2>&1 || true
+    brew trust "$tap" >/dev/null 2>&1 || true
+  done
+
+  log "Installing Homebrew packages (brew bundle --no-upgrade)"
+  make -C "$REPO_DIR" brew
+else
+  log "Skipping Homebrew (non-macOS)"
+fi
+
+# --- git submodules (zsh plugins) --------------------------------------------
+log "Initializing git submodules"
+git -C "$REPO_DIR" submodule update --init
+
+# --- symlinks -----------------------------------------------------------------
+log "Symlinking dotfiles and .config into \$HOME"
+make -C "$REPO_DIR" dotfiles
+make -C "$REPO_DIR" config
+
+# --- asdf and runtimes --------------------------------------------------------
+if [ ! -d "$HOME/.asdf" ]; then
+  log "Installing asdf ($ASDF_VERSION)"
+  git clone https://github.com/asdf-vm/asdf.git "$HOME/.asdf" --branch "$ASDF_VERSION"
+fi
+
+log "Installing asdf runtimes from .tool-versions"
+# shellcheck disable=SC1091
+. "$HOME/.asdf/asdf.sh"
+while read -r tool version; do
+  case "$tool" in '' | \#*) continue ;; esac
+  asdf plugin add "$tool" 2>/dev/null || true
+  asdf install "$tool" "$version"
+done <"$REPO_DIR/.tool-versions"
+
+# --- macOS defaults -----------------------------------------------------------
+if [ "$(uname)" = "Darwin" ]; then
+  log "Setting macOS key-repeat defaults"
+  defaults write -g InitialKeyRepeat -int 12 # normal minimum is 15 (225 ms)
+  defaults write -g KeyRepeat -int 1         # normal minimum is 2 (30 ms)
+fi
+
+log "Done. Start a new zsh to pick everything up."

--- a/install_shell.sh
+++ b/install_shell.sh
@@ -1,9 +1,0 @@
-# Install oh-my-zsh
-exec sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
-
-# Clone zsh auto suggestions
-git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions
-
-# set default key repeat
-defaults write -g InitialKeyRepeat -int 12 # normal minimum is 15 (225 ms)
-defaults write -g KeyRepeat -int 1 # normal minimum is 2 (30 ms)


### PR DESCRIPTION
## Summary
- Add `install.sh` (also reachable as `make bootstrap`): idempotent one-command setup — installs Homebrew if missing (macOS), taps + trusts the third-party taps so `brew bundle` runs non-interactively, runs `make brew`, initializes the zsh-plugin git submodules, symlinks dotfiles and `.config`, clones asdf `v0.13.1` (the version `.zshrc` expects) and installs every runtime in `.tool-versions`, and applies the macOS key-repeat defaults
- Retire `install_shell.sh`: its oh-my-zsh install isn't used by `.zshrc` (and its `exec` meant the following clone step never ran), the plugin clone is superseded by the submodules, and the key-repeat defaults moved into `install.sh`
- README: replace the 2019 screenshot section with bootstrap-first instructions
- CI: shellcheck now also lints `install.sh`

## Test plan
- `shellcheck` + `bash -n` clean
- Ran `./install.sh` end-to-end on a fully-provisioned machine: every step correctly no-ops (brew bundle satisfied, submodules initialized, symlinks refreshed, all 8 asdf runtimes detected as installed)
- Fresh-machine paths are guarded (`command -v brew`, `! -d ~/.asdf`, plugin add `|| true`)

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)