### PR TITLE
test: add bats tests for .scripts and run them in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,16 @@ jobs:
           bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
 
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install bats and lsof
+        run: sudo apt-get update && sudo apt-get install -y bats lsof
+      - name: Run script tests
+        run: bats test/scripts.bats
+
   gitleaks:
     runs-on: ubuntu-latest
     steps:

--- a/.scripts/tssh
+++ b/.scripts/tssh
@@ -32,31 +32,6 @@ Without -p/-t: Linux hosts use `tailscale ssh`, others use plain ssh.
 EOF
 }
 
-# The macOS App Store build hides the CLI inside the app bundle. Under WSL there
-# is usually no Linux tailscaled, so fall back to the Windows client: WSL2 routes
-# to the tailnet through the host, and MagicDNS resolves via the host's resolver,
-# so listing and plain ssh both work. Its `ssh` subcommand does not -- it spawns a
-# Windows ssh.exe, which dies with CreateProcessW error:2 when called from WSL.
-ts_is_win=0
-if command -v tailscale >/dev/null 2>&1; then
-  TS=tailscale
-elif [[ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]]; then
-  TS=/Applications/Tailscale.app/Contents/MacOS/Tailscale
-elif [[ -x "/mnt/c/Program Files/Tailscale/tailscale.exe" ]]; then
-  TS="/mnt/c/Program Files/Tailscale/tailscale.exe"
-  ts_is_win=1
-else
-  echo "tailscale not found" >&2
-  exit 1
-fi
-
-for cmd in jq fzf; do
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "$cmd is required but not installed" >&2
-    exit 1
-  fi
-done
-
 list_only=0
 show_all=0
 mode="auto"
@@ -81,6 +56,32 @@ if [[ "$query" == *@* ]]; then
   user="${query%%@*}"
   query="${query#*@}"
 fi
+
+# Dependency checks come after parsing so --help works without tailscale.
+# The macOS App Store build hides the CLI inside the app bundle. Under WSL there
+# is usually no Linux tailscaled, so fall back to the Windows client: WSL2 routes
+# to the tailnet through the host, and MagicDNS resolves via the host's resolver,
+# so listing and plain ssh both work. Its `ssh` subcommand does not -- it spawns a
+# Windows ssh.exe, which dies with CreateProcessW error:2 when called from WSL.
+ts_is_win=0
+if command -v tailscale >/dev/null 2>&1; then
+  TS=tailscale
+elif [[ -x /Applications/Tailscale.app/Contents/MacOS/Tailscale ]]; then
+  TS=/Applications/Tailscale.app/Contents/MacOS/Tailscale
+elif [[ -x "/mnt/c/Program Files/Tailscale/tailscale.exe" ]]; then
+  TS="/mnt/c/Program Files/Tailscale/tailscale.exe"
+  ts_is_win=1
+else
+  echo "tailscale not found" >&2
+  exit 1
+fi
+
+for cmd in jq fzf; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd is required but not installed" >&2
+    exit 1
+  fi
+done
 
 status_file=$(mktemp)
 trap 'rm -f "$status_file"' EXIT

--- a/test/README.md
+++ b/test/README.md
@@ -4,6 +4,15 @@ This directory contains test cases for various functions and scripts in the dotf
 
 ## Contents
 
+### scripts.bats
+
+Automated [bats-core](https://github.com/bats-core/bats-core) tests for the non-interactive behaviors of the tools in `.scripts/` (`urlencode`, `killport`, help/usage flags, and the outside-tmux guards). These run in CI on every push; locally:
+
+```bash
+brew install bats-core
+bats test/scripts.bats
+```
+
 ### test-package-scripts
 
 A test package to demonstrate the basic `run-script` function added to your .zshrc file. This test shows how to use the function to list and run npm scripts using fzf.

--- a/test/scripts.bats
+++ b/test/scripts.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+
+# Tests for the non-interactive behaviors of the tools in .scripts/.
+# Run locally with `bats test/scripts.bats` (brew install bats-core).
+# The fzf/tmux-interactive scripts (pmux, tmux-window-fzf, switch-worktree)
+# can only be exercised by hand and are not covered here.
+
+SCRIPTS="$BATS_TEST_DIRNAME/../.scripts"
+
+# --- urlencode ---------------------------------------------------------------
+
+@test "urlencode passes through safe characters" {
+  run "$SCRIPTS/urlencode" "abc-DEF_123.~"
+  [ "$status" -eq 0 ]
+  [ "$output" = "abc-DEF_123.~" ]
+}
+
+@test "urlencode encodes spaces" {
+  run "$SCRIPTS/urlencode" "test ok"
+  [ "$status" -eq 0 ]
+  [ "$output" = "test%20ok" ]
+}
+
+@test "urlencode encodes reserved characters" {
+  run "$SCRIPTS/urlencode" "a/b?c=d&e"
+  [ "$status" -eq 0 ]
+  [ "$output" = "a%2fb%3fc%3dd%26e" ]
+}
+
+@test "urlencode joins multiple arguments with a space" {
+  run "$SCRIPTS/urlencode" foo bar
+  [ "$status" -eq 0 ]
+  [ "$output" = "foo%20bar" ]
+}
+
+@test "urlencode encodes stdin lines" {
+  run bash -c "printf 'a b\nc d\n' | '$SCRIPTS/urlencode'"
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "a%20b" ]
+  [ "${lines[1]}" = "c%20d" ]
+}
+
+# --- killport ----------------------------------------------------------------
+
+@test "killport without arguments prints usage and fails" {
+  run "$SCRIPTS/killport"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage: killport <port>"* ]]
+}
+
+@test "killport rejects a non-numeric port" {
+  run "$SCRIPTS/killport" abc
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Port must be a number"* ]]
+}
+
+@test "killport succeeds when nothing listens on the port" {
+  run "$SCRIPTS/killport" 64999
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No processes found"* ]]
+}
+
+@test "killport kills a process listening on the port" {
+  command -v python3 >/dev/null || skip "python3 not available"
+  port=58231
+  python3 -m http.server "$port" >/dev/null 2>&1 &
+  server_pid=$!
+  # wait for the server to be up
+  for _ in $(seq 1 20); do
+    lsof -ti:"$port" >/dev/null 2>&1 && break
+    sleep 0.2
+  done
+  lsof -ti:"$port" >/dev/null 2>&1 || skip "test server failed to start"
+
+  run "$SCRIPTS/killport" "$port"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Killing processes on port $port"* ]]
+
+  # the listener should be gone shortly after
+  for _ in $(seq 1 20); do
+    lsof -ti:"$port" >/dev/null 2>&1 || break
+    sleep 0.2
+  done
+  ! lsof -ti:"$port" >/dev/null 2>&1
+  ! kill -0 "$server_pid" 2>/dev/null
+}
+
+# --- tmux helpers outside tmux ----------------------------------------------
+
+@test "tmux-pane-name fails outside tmux" {
+  run env -u TMUX "$SCRIPTS/tmux-pane-name" some-name
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Not in a tmux session"* ]]
+}
+
+@test "tmux-pane-highlight is a silent no-op outside tmux" {
+  run env -u TMUX -u TMUX_PANE "$SCRIPTS/tmux-pane-highlight" red
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "tmux-cleanup-windows fails outside tmux" {
+  run env -u TMUX "$SCRIPTS/tmux-cleanup-windows.sh"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Not in a tmux session"* ]]
+}
+
+# --- help/usage flags --------------------------------------------------------
+
+@test "tmux-send-all --help prints usage" {
+  run "$SCRIPTS/tmux-send-all" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: tmux-send-all"* ]]
+}
+
+@test "tmux-send-all rejects mixing --target and --ignore" {
+  run "$SCRIPTS/tmux-send-all" -t 1 -i 2 -c ls
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"mutually exclusive"* ]]
+}
+
+@test "tssh --help prints usage" {
+  run "$SCRIPTS/tssh" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: tssh"* ]]
+}
+
+@test "tssh rejects unknown options" {
+  run "$SCRIPTS/tssh" --bogus
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unknown option"* ]]
+}


### PR DESCRIPTION
## Summary
- Add `test/scripts.bats` — 16 bats-core tests covering the non-interactive behaviors of `.scripts/`:
  - `urlencode`: safe chars, spaces, reserved chars, multi-arg joining, stdin mode
  - `killport`: usage/invalid-port/no-process paths, plus a real kill test against a throwaway `python3 -m http.server` listener
  - outside-tmux guards: `tmux-pane-name` and `tmux-cleanup-windows.sh` fail cleanly, `tmux-pane-highlight` is a silent no-op (hook safety)
  - flag handling: `tmux-send-all` help + `-t`/`-i` mutual exclusion, `tssh` help + unknown-option rejection
- Add a `bats` CI job to lint.yml (apt-installed bats + lsof on ubuntu)
- Document the suite in `test/README.md`

The fzf/tmux-interactive scripts (`pmux`, `tmux-window-fzf`, `switch-worktree`) are inherently manual and stay uncovered.

## Test plan
- All 16 tests pass locally on macOS (run from inside a tmux session — the `env -u TMUX` guards keep them deterministic)
- `actionlint` clean on the workflow change

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)