### PR TITLE
feat(tmux): show Claude state as a readable status with elapsed time

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,8 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install bats and lsof
-        run: sudo apt-get update && sudo apt-get install -y bats lsof
+      - name: Install bats, lsof and tmux
+        run: sudo apt-get update && sudo apt-get install -y bats lsof tmux
       - name: Run script tests
         run: bats test/scripts.bats
 

--- a/.scripts/tmux-claude-elapsed
+++ b/.scripts/tmux-claude-elapsed
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# tmux-claude-elapsed: Print a compact elapsed-time label ("45s", "12m", "2h05m")
+# for the epoch-seconds timestamp given as $1. Prints nothing (and still exits 0)
+# when the argument is missing or not a number, so it can be embedded in the tmux
+# status line as #(tmux-claude-elapsed #{@claude_at}) without leaving garbage
+# when no Claude mark is set.
+
+at="$1"
+[[ "$at" =~ ^[0-9]+$ ]] || exit 0
+
+now=$(date +%s)
+elapsed=$(( now - at ))
+(( elapsed < 0 )) && elapsed=0
+
+if (( elapsed < 60 )); then
+    echo "${elapsed}s"
+elif (( elapsed < 3600 )); then
+    echo "$(( elapsed / 60 ))m"
+else
+    printf '%dh%02dm\n' "$(( elapsed / 3600 ))" "$(( (elapsed % 3600) / 60 ))"
+fi

--- a/.scripts/tmux-pane-highlight
+++ b/.scripts/tmux-pane-highlight
@@ -6,7 +6,9 @@
 #   tmux-pane-highlight off       # clear (revert pane border + window indicator)
 # Sets @pane_color on the pane (drives the border color via .tmux.conf) and
 # @claude_status on the window (drives a colored-emoji prefix in the Catppuccin
-# window status). No-op when not inside tmux, so it is safe to call from hooks.
+# window status). Also records @claude_at (epoch seconds) on both scopes so the
+# status line can show how long the mark has been up (see tmux-claude-elapsed).
+# No-op when not inside tmux, so it is safe to call from hooks.
 
 [[ -z "$TMUX" || -z "$TMUX_PANE" ]] && exit 0
 
@@ -14,7 +16,9 @@ color="${1:-off}"
 
 if [[ "$color" == "off" ]]; then
     tmux set-option -p -t "$TMUX_PANE" -u @pane_color 2>/dev/null || true
+    tmux set-option -p -t "$TMUX_PANE" -u @claude_at 2>/dev/null || true
     tmux set-option -w -t "$TMUX_PANE" -u @claude_status 2>/dev/null || true
+    tmux set-option -w -t "$TMUX_PANE" -u @claude_at 2>/dev/null || true
     exit 0
 fi
 
@@ -28,5 +32,8 @@ case "$color" in
     *)       icon="⏺" ;;
 esac
 
+now=$(date +%s)
 tmux set-option -p -t "$TMUX_PANE" @pane_color "$color"
+tmux set-option -p -t "$TMUX_PANE" @claude_at "$now"
 tmux set-option -w -t "$TMUX_PANE" @claude_status "$icon"
+tmux set-option -w -t "$TMUX_PANE" @claude_at "$now"

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -28,6 +28,8 @@ bind-key , command-prompt "rename-window '%%'"
 bind -T copy-mode-vi v send-keys -X begin-selection
 
 set-option -g status-position top
+# Claudeマークの経過時間表示 (tmux-claude-elapsed) を進めるために定期再描画する
+set -g status-interval 15
 set-option default-terminal "screen-256color"
 # Plugins (TPM は未導入なら自動で clone される / <prefix> + I で追加インストール)
 set -g @plugin 'tmux-plugins/tpm'
@@ -58,12 +60,12 @@ set -g @catppuccin_window_right_separator "█ "
 set -g @catppuccin_window_middle_separator " █"
 set -g @catppuccin_window_number_position "right"
 
-set -g @catppuccin_window_text "#{?#{@claude_status},#{@claude_status} ,}#W"
+set -g @catppuccin_window_text "#{?#{@claude_status},#{@claude_status} #(~/.scripts/tmux-claude-elapsed #{@claude_at}) ,}#W"
 set -g @catppuccin_window_default_fill "number"
-set -g @catppuccin_window_default_text "#{?#{@claude_status},#{@claude_status} ,}#W"
+set -g @catppuccin_window_default_text "#{?#{@claude_status},#{@claude_status} #(~/.scripts/tmux-claude-elapsed #{@claude_at}) ,}#W"
 
 set -g @catppuccin_window_current_fill "number"
-set -g @catppuccin_window_current_text "#{?#{@claude_status},#{@claude_status} ,}#W"
+set -g @catppuccin_window_current_text "#{?#{@claude_status},#{@claude_status} #(~/.scripts/tmux-claude-elapsed #{@claude_at}) ,}#W"
 
 set -g @catppuccin_status_modules_right "directory user session"
 set -g @catppuccin_status_left_separator  "█"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `make` or `make dotfiles` — symlink all dotfiles (`.??*` except `.git`, `.gitignore`, etc.) into `$HOME`
 - `make config` — symlink `.config/*` entries into `$HOME/.config/`
+- `make claude` — symlink `configs/claude/settings.json` to `~/.claude/settings.json` (Claude Code hooks etc.; machine-local state like `feedbackSurveyState` is intentionally not committed)
 - `make vscodeExtensions` — sync VSCode extensions via `configs/.vscode/vscodeSync.sh`
 - `make list` — show which dotfiles will be symlinked
 - `make help` — print all make targets

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VSCODE_SCRIPT_PATH := $(abspath configs/.vscode)
 CONFIG_PATH := $(wildcard .config/??*)
 .DEFAULT_GOAL	:= dotfiles
 
-.PHONY: list dotfiles config unlink brew bootstrap vscodeExtensions help
+.PHONY: list dotfiles config claude unlink brew bootstrap vscodeExtensions help
 
 list: # Show dotfiles in this repository
 	@echo 'list - Showing list of dotfiles in this repository'
@@ -24,6 +24,13 @@ config: # Create symlinks of .config at home directory
 	@echo '------------------------'
 	@echo $(abspath $(CONFIG_PATH))
 	@$(foreach val, $(CONFIG_PATH), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
+	@echo '------------------------'
+
+claude: # Create symlink of Claude Code settings.json in ~/.claude
+	@echo 'claude - Setting symlink of Claude Code settings.json in ~/.claude'
+	@echo '------------------------'
+	@mkdir -p $(HOME)/.claude
+	@ln -sfnv $(abspath configs/claude/settings.json) $(HOME)/.claude/settings.json
 	@echo '------------------------'
 
 unlink: # Remove dotfile symlinks from home directory

--- a/configs/claude/settings.json
+++ b/configs/claude/settings.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "model": "claude-fable-5[1m]",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "afplay ~/Music/daisuki.mp3"
+          },
+          {
+            "type": "command",
+            "command": "tmux-pane-highlight yellow"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "afplay ~/Music/daisuki.mp3"
+          },
+          {
+            "type": "command",
+            "command": "tmux-pane-highlight red"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-pane-highlight green"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-pane-highlight off"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "swift-lsp@claude-plugins-official": true
+  },
+  "effortLevel": "high",
+  "skipAutoPermissionPrompt": true
+}

--- a/test/scripts.bats
+++ b/test/scripts.bats
@@ -7,6 +7,27 @@
 
 SCRIPTS="$BATS_TEST_DIRNAME/../.scripts"
 
+# Scratch tmux server for the tmux-pane-highlight tests. The highlight script
+# resolves the server from $TMUX, so pointing that at the scratch socket keeps
+# the tests away from any real tmux session.
+TMUX_SOCKET="bats-tph-$$"
+
+teardown() {
+  tmux -L "$TMUX_SOCKET" kill-server 2>/dev/null || true
+}
+
+start_scratch_tmux() {
+  command -v tmux >/dev/null || skip "tmux not available"
+  tmux -L "$TMUX_SOCKET" -f /dev/null new-session -d -x 80 -y 24
+  TEST_PANE=$(tmux -L "$TMUX_SOCKET" display-message -p '#{pane_id}')
+  TEST_TMUX="$(tmux -L "$TMUX_SOCKET" display-message -p '#{socket_path}'),0,0"
+}
+
+# Read a pane/window user option from the scratch server; empty when unset.
+scratch_opt() {
+  tmux -L "$TMUX_SOCKET" show-options "$1" -t "$TEST_PANE" -v "$2" 2>/dev/null || true
+}
+
 # --- urlencode ---------------------------------------------------------------
 
 @test "urlencode passes through safe characters" {
@@ -103,6 +124,69 @@ SCRIPTS="$BATS_TEST_DIRNAME/../.scripts"
   run env -u TMUX "$SCRIPTS/tmux-cleanup-windows.sh"
   [ "$status" -eq 1 ]
   [[ "$output" == *"Not in a tmux session"* ]]
+}
+
+# --- tmux-pane-highlight inside a scratch tmux server -------------------------
+
+@test "tmux-pane-highlight sets color, icon, and @claude_at timestamp" {
+  start_scratch_tmux
+  before=$(date +%s)
+
+  run env TMUX="$TEST_TMUX" TMUX_PANE="$TEST_PANE" "$SCRIPTS/tmux-pane-highlight" yellow
+  [ "$status" -eq 0 ]
+
+  [ "$(scratch_opt -p @pane_color)" = "yellow" ]
+  [ "$(scratch_opt -w @claude_status)" = "🟡" ]
+  pane_at=$(scratch_opt -p @claude_at)
+  [[ "$pane_at" =~ ^[0-9]+$ ]]
+  [ "$pane_at" -ge "$before" ]
+  # window scope carries the same timestamp for the status-line display
+  [ "$(scratch_opt -w @claude_at)" = "$pane_at" ]
+}
+
+@test "tmux-pane-highlight off clears pane and window options" {
+  start_scratch_tmux
+  env TMUX="$TEST_TMUX" TMUX_PANE="$TEST_PANE" "$SCRIPTS/tmux-pane-highlight" red
+
+  run env TMUX="$TEST_TMUX" TMUX_PANE="$TEST_PANE" "$SCRIPTS/tmux-pane-highlight" off
+  [ "$status" -eq 0 ]
+
+  [ -z "$(scratch_opt -p @pane_color)" ]
+  [ -z "$(scratch_opt -p @claude_at)" ]
+  [ -z "$(scratch_opt -w @claude_status)" ]
+  [ -z "$(scratch_opt -w @claude_at)" ]
+}
+
+# --- tmux-claude-elapsed ------------------------------------------------------
+
+@test "tmux-claude-elapsed prints nothing without an argument" {
+  run "$SCRIPTS/tmux-claude-elapsed"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "tmux-claude-elapsed prints nothing for a non-numeric argument" {
+  run "$SCRIPTS/tmux-claude-elapsed" "not-a-timestamp"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "tmux-claude-elapsed prints seconds under a minute" {
+  run "$SCRIPTS/tmux-claude-elapsed" "$(( $(date +%s) - 5 ))"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]+s$ ]]
+}
+
+@test "tmux-claude-elapsed prints minutes under an hour" {
+  run "$SCRIPTS/tmux-claude-elapsed" "$(( $(date +%s) - 120 ))"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2m" ]
+}
+
+@test "tmux-claude-elapsed prints hours and minutes" {
+  run "$SCRIPTS/tmux-claude-elapsed" "$(( $(date +%s) - 7500 ))"
+  [ "$status" -eq 0 ]
+  [ "$output" = "2h05m" ]
 }
 
 # --- help/usage flags --------------------------------------------------------


### PR DESCRIPTION
## 背景

Claude Code が止まると🟡、権限待ちで🔴が付くが、マークが「イベント発生時に付く」だけなので、pane が今も動いているのか終わって放置されているのか判別できなかった。

## 変更内容

- **UserPromptSubmit hook を `off` → `green` に変更** — 実行中は🟢が付き、「マークなし = Claude 不在」と区別できる。`SessionEnd → off` は据え置き
- **`tmux-pane-highlight` が `@claude_at` (epoch) を記録** — pane / window 両スコープにセットし、`off` で unset
- **新スクリプト `.scripts/tmux-claude-elapsed`** — `45s` / `12m` / `2h05m` 形式で経過時間を出力。window status が `🟡 12m` のようになり、放置検出ができる。`status-interval 15` で定期再描画
- **`~/.claude/settings.json` を dotfiles 管理化** — `configs/claude/settings.json` に置き、`make claude` で symlink。`feedbackSurveyState` などマシンローカル状態は管理外に落とした
- **bats テスト追加** — scratch tmux サーバー (`tmux -L`) を立てて `@claude_at` の set/unset を検証、`tmux-claude-elapsed` の出力境界も検証。CI の bats ジョブに tmux をインストール

## 検証

- `bats test/scripts.bats` 23件 pass（ローカル macOS）
- `shellcheck` clean
- ライブ tmux サーバーで reload 済み: `tmux-pane-highlight yellow` → border 黄 + `@claude_at` に epoch、`off` → 全 unset を確認
- 🟢/🟡/🔴 の遷移は実セッションでの目視確認を推奨

## 既知の制限

- `@claude_status` / `@claude_at` は window スコープなので、同一 window に複数 Claude pane があると上書き合戦になる（border 色は pane 単位で正しい）
- 権限承認や task notification 経由の再開は UserPromptSubmit を発火しないため、動作再開しても🔴/🟡が残るケースは引き続きある

🤖 Generated with [Claude Code](https://claude.com/claude-code)