### PR TITLE
ci: cover make config, unlink and Linux in the main workflow

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -5,8 +5,11 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      # Report both platforms even when one fails; the Makefile hits GNU vs BSD
+      # differences (ln, mktemp) that are only visible per-OS.
+      fail-fast: false
       matrix:
-        os: [macOS-latest]
+        os: [macOS-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -14,5 +17,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Install bats (macOS)
+        if: runner.os == 'macOS'
+        run: brew install bats-core
+
+      - name: Install bats (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      # Exercises dotfiles/config/claude/unlink against a throwaway $HOME and
+      # asserts on the symlinks produced, not just on make's exit status.
+      - name: Run Makefile tests
+        run: bats test/makefile.bats
+
+      # Still run the real thing against the runner's own $HOME, so the
+      # everyday `make` path stays covered on both platforms.
       - name: Run Make
         run: make

--- a/test/README.md
+++ b/test/README.md
@@ -13,6 +13,17 @@ brew install bats-core
 bats test/scripts.bats
 ```
 
+### makefile.bats
+
+Automated [bats-core](https://github.com/bats-core/bats-core) tests for the symlink targets in the `Makefile` (`dotfiles`, `config`, `claude`, `unlink`, `list`, `help`). Each test points `HOME` at a throwaway directory, so a fresh machine is reproduced without touching the real one, and asserts on the symlinks that were actually produced — `ln -sfn` can fail in ways that still leave `make` green. These run in CI on both macOS and Linux; locally:
+
+```bash
+brew install bats-core
+bats test/makefile.bats
+```
+
+A few tests are marked `skip` because they cover bugs that are still open (#259, #260). They are written to pass once those are fixed — drop the `skip` line as part of the fix.
+
 ### test-package-scripts
 
 A test package to demonstrate the basic `run-script` function added to your .zshrc file. This test shows how to use the function to list and run npm scripts using fzf.

--- a/test/makefile.bats
+++ b/test/makefile.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+
+# Tests for the symlink targets in the Makefile (dotfiles / config / unlink).
+#
+# Everything runs against a throwaway $HOME, so a fresh machine is reproduced
+# without touching the real one. `make` is checked for what it actually
+# produced, not just for exit status: `ln -sfn` fails silently in ways that
+# still leave make green (see #260).
+#
+# Run locally with `bats test/makefile.bats` (brew install bats-core).
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  FAKE_HOME="$(mktemp -d)"
+}
+
+teardown() {
+  [ -n "${FAKE_HOME:-}" ] && rm -rf "$FAKE_HOME"
+}
+
+# `readlink -f` is GNU-only, and these tests also run on macOS, so compare
+# against the single-level link target that the Makefile writes.
+assert_links_to() {
+  [ -L "$1" ]
+  [ "$(readlink "$1")" = "$2" ]
+}
+
+# --- make dotfiles -----------------------------------------------------------
+
+@test "make dotfiles symlinks a dotfile into HOME" {
+  run make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.zshrc" "$REPO/.zshrc"
+}
+
+@test "make dotfiles symlinks a directory into HOME" {
+  run make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.scripts" "$REPO/.scripts"
+  # .scripts is symlinked as a whole, so new scripts land in $HOME for free.
+  [ -x "$FAKE_HOME/.scripts/pmux" ]
+}
+
+@test "make dotfiles skips repository-only entries" {
+  run make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  for entry in .git .github .gitignore .gitmodules .config; do
+    [ ! -e "$FAKE_HOME/$entry" ]
+  done
+}
+
+@test "make dotfiles is idempotent" {
+  make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  run make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.zshrc" "$REPO/.zshrc"
+  # A second run must not bury the link inside the first one.
+  [ ! -e "$FAKE_HOME/.scripts/.scripts" ]
+}
+
+@test "make dotfiles replaces a pre-existing regular file" {
+  echo "stale" >"$FAKE_HOME/.zshrc"
+  run make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.zshrc" "$REPO/.zshrc"
+}
+
+@test "make dotfiles does not nest the link inside an existing real directory" {
+  skip "known bug, tracked in #260"
+  mkdir -p "$FAKE_HOME/.vim/pack"
+  run make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  [ ! -e "$FAKE_HOME/.vim/.vim" ]
+}
+
+@test "make dotfiles does not symlink repository tooling directories" {
+  skip "known bug, tracked in #260"
+  make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  [ ! -e "$FAKE_HOME/.devcontainer" ]
+  [ ! -e "$FAKE_HOME/.vscode" ]
+}
+
+# --- make config -------------------------------------------------------------
+
+@test "make config symlinks .config entries into HOME/.config" {
+  mkdir -p "$FAKE_HOME/.config"
+  run make -C "$REPO" config HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.config/nvim" "$REPO/.config/nvim"
+}
+
+@test "make config succeeds when HOME/.config does not exist yet" {
+  skip "known bug, tracked in #259"
+  run make -C "$REPO" config HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.config/nvim" "$REPO/.config/nvim"
+}
+
+# --- make claude -------------------------------------------------------------
+
+@test "make claude creates ~/.claude and symlinks settings.json" {
+  run make -C "$REPO" claude HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.claude/settings.json" "$REPO/configs/claude/settings.json"
+}
+
+# --- make unlink -------------------------------------------------------------
+
+@test "make unlink removes the symlinks it created" {
+  mkdir -p "$FAKE_HOME/.config"
+  make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  make -C "$REPO" config HOME="$FAKE_HOME"
+  [ -L "$FAKE_HOME/.zshrc" ]
+
+  run make -C "$REPO" unlink HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  [ ! -e "$FAKE_HOME/.zshrc" ]
+  [ ! -e "$FAKE_HOME/.scripts" ]
+  [ ! -e "$FAKE_HOME/.config/nvim" ]
+}
+
+@test "make unlink leaves files it did not create alone" {
+  echo "mine" >"$FAKE_HOME/.zshrc"
+  run make -C "$REPO" unlink HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  [ -f "$FAKE_HOME/.zshrc" ]
+  [ "$(cat "$FAKE_HOME/.zshrc")" = "mine" ]
+}
+
+# --- make list / help --------------------------------------------------------
+
+@test "make list names the dotfiles it would link" {
+  run make -C "$REPO" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *".zshrc"* ]]
+  [[ "$output" == *".tmux.conf"* ]]
+}
+
+@test "make help lists the available targets" {
+  run make -C "$REPO" help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dotfiles:"* ]]
+  [[ "$output" == *"config:"* ]]
+  [[ "$output" == *"unlink:"* ]]
+}


### PR DESCRIPTION
Closes #261.

`make.yml` は macOS 上の `make` しか実行していなかったため、`make config` / `make unlink` / Linux のコードパスが一度も検証されていませんでした。未修正の Makefile バグ (#259, #260) がこのギャップをすり抜けており、特に #260 は **make の終了コードに現れない**ため、`make` を流すだけでは今後も検出できません。

## 変更内容

### `test/makefile.bats`（新規・14 テスト）

`HOME` を使い捨てディレクトリに向けて `dotfiles` / `config` / `claude` / `unlink` / `list` / `help` を実行し、**実際に張られた symlink を検証**します。「`make` が rc=0」で終わらせない、というのが issue の主眼だったのでそこを重視しました。

主なカバー範囲:

- ファイル / ディレクトリが `$HOME` に正しくリンクされるか
- リポジトリ専用エントリ (`.git`, `.github`, `.gitignore`, `.gitmodules`, `.config`) が貼られていないか
- 冪等性 — 2 回目の実行で入れ子にならないか
- 既存の通常ファイルを置き換えられるか
- `make unlink` が自分で作った symlink だけを消し、**ユーザーの実ファイルには触れない**か
- `make claude` が `~/.claude` を作って `settings.json` を貼るか

`readlink -f` は GNU 限定なので、macOS でも動くよう 1 階層の比較にしています。

### `.github/workflows/make.yml`

- matrix に `ubuntu-latest` を追加（`fail-fast: false` で両 OS の結果を出す）
- 両 OS に bats を入れて `bats test/makefile.bats` を実行
- 従来どおり実 `$HOME` に対する `make` も残し、日常の経路を両 OS でカバー

### `test/README.md`

新テストの説明を追記。

## #259 / #260 のテストについて

該当する 3 テストは**書いた上で `skip`** にしています。バグ自体はこの PR のスコープ外なので、有効にすると CI が赤くなるためです。

`skip` を外して実行し、それぞれ意図した箇所で落ちることを確認済みです:

```
not ok 6 ... does not nest the link inside an existing real directory
#   `[ ! -e "$FAKE_HOME/.vim/.vim" ]' failed
not ok 7 ... does not symlink repository tooling directories
#   `[ ! -e "$FAKE_HOME/.devcontainer" ]' failed
not ok 9 make config succeeds when HOME/.config does not exist yet
#   `[ "$status" -eq 0 ]' failed
```

バグ修正時は `skip` の行を消すだけでそのまま回帰テストになります。

## 動作確認

- `bats test/makefile.bats` → 14/14 pass（うち skip 3）
- `actionlint` → clean
- workflow の YAML パース確認済み

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_