### PR TITLE
fix: create ~/.config before symlinking into it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ config: # Create symlinks of .config at home directory
 	@echo 'config - Setting symlinks of .config in HOME directory'
 	@echo '------------------------'
 	@echo $(abspath $(CONFIG_PATH))
+	@mkdir -p $(HOME)/.config
 	@$(foreach val, $(CONFIG_PATH), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
 	@echo '------------------------'
 

--- a/test/README.md
+++ b/test/README.md
@@ -22,7 +22,7 @@ brew install bats-core
 bats test/makefile.bats
 ```
 
-A few tests are marked `skip` because they cover bugs that are still open (#259, #260). They are written to pass once those are fixed — drop the `skip` line as part of the fix.
+A couple of tests are marked `skip` because they cover a bug that is still open (#260). They are written to pass once it is fixed — drop the `skip` line as part of the fix.
 
 ### test-package-scripts
 

--- a/test/makefile.bats
+++ b/test/makefile.bats
@@ -89,7 +89,6 @@ assert_links_to() {
 }
 
 @test "make config succeeds when HOME/.config does not exist yet" {
-  skip "known bug, tracked in #259"
   run make -C "$REPO" config HOME="$FAKE_HOME"
   [ "$status" -eq 0 ]
   assert_links_to "$FAKE_HOME/.config/nvim" "$REPO/.config/nvim"


### PR DESCRIPTION
Closes #259.

`make config` が `$HOME/.config` に直接 symlink を張っていたので、そのディレクトリがまだ無いマシンだと全件失敗して `Error 1` で落ちていました。`install.sh` は `set -euo pipefail` の下でこれを呼ぶため、まっさらなマシンでは **asdf のインストールと macOS の key-repeat 設定まで到達していません**でした。

## 変更内容

`claude` ターゲットと同じように `mkdir -p` を 1 行足しただけです。

```make
config:
	@mkdir -p $(HOME)/.config
	@$(foreach val, $(CONFIG_PATH), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
```

あわせて #262 で入れておいた回帰テストの `skip` を外しました。`test/README.md` の記述も残る #260 のぶんだけに更新しています。

## 動作確認

- `bats test/makefile.bats` → 14/14 pass（skip は #260 の 2 件のみ）
- `make config succeeds when HOME/.config does not exist yet` が skip 無しで green になることを確認
- 空の `$HOME` に対して `make dotfiles` → `make config` が両方 rc=0 で通り、`.config/*` の symlink が張れることを確認（`install.sh` が踏む経路）

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_