### PR TITLE
fix: stop nesting symlinks inside existing directories in $HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,22 @@
 DOTFILES 	:= $(wildcard .??*)
-IGNORE	:= .DS_Store .git .gitmodules .gitignore .github .config
+# .devcontainer and .vscode configure this repository, not $HOME. ~/.vscode in
+# particular is VSCode's own extensions directory, so linking over it is wrong.
+IGNORE	:= .DS_Store .git .gitmodules .gitignore .github .config .devcontainer .vscode
 TARGET	:= $(filter-out $(IGNORE), $(DOTFILES))
 VSCODE_SCRIPT_PATH := $(abspath configs/.vscode)
 CONFIG_PATH := $(wildcard .config/??*)
 .DEFAULT_GOAL	:= dotfiles
 
 .PHONY: list dotfiles config claude unlink brew bootstrap vscodeExtensions help
+
+# link <source> <destination>
+# `ln -sfn dest` puts the link *inside* dest when dest is already a real
+# directory, which leaves make green while the config never takes effect. Skip
+# those instead, so a directory we did not create is never touched. A plain
+# file is still replaced -- overwriting a stock ~/.bashrc is the whole point.
+define link
+if [ -d "$(2)" ] && [ ! -L "$(2)" ]; then echo "skip $(2): already a directory, remove or rename it to link"; else ln -sfnv "$(1)" "$(2)"; fi;
+endef
 
 list: # Show dotfiles in this repository
 	@echo 'list - Showing list of dotfiles in this repository'
@@ -16,7 +27,7 @@ list: # Show dotfiles in this repository
 dotfiles: # Create symlinks of dotfiles to home directory
 	@echo 'dotfiles - Setting symlinks of dotfiles in HOME directory'
 	@echo '------------------------'
-	@$(foreach val, $(TARGET), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
+	@$(foreach val, $(TARGET), $(call link,$(abspath $(val)),$(HOME)/$(val)))
 	@echo '------------------------'
 
 config: # Create symlinks of .config at home directory
@@ -24,7 +35,7 @@ config: # Create symlinks of .config at home directory
 	@echo '------------------------'
 	@echo $(abspath $(CONFIG_PATH))
 	@mkdir -p $(HOME)/.config
-	@$(foreach val, $(CONFIG_PATH), ln -sfnv $(abspath $(val)) $(HOME)/$(val);)
+	@$(foreach val, $(CONFIG_PATH), $(call link,$(abspath $(val)),$(HOME)/$(val)))
 	@echo '------------------------'
 
 claude: # Create symlink of Claude Code settings.json in ~/.claude

--- a/test/README.md
+++ b/test/README.md
@@ -22,8 +22,6 @@ brew install bats-core
 bats test/makefile.bats
 ```
 
-A couple of tests are marked `skip` because they cover a bug that is still open (#260). They are written to pass once it is fixed — drop the `skip` line as part of the fix.
-
 ### test-package-scripts
 
 A test package to demonstrate the basic `run-script` function added to your .zshrc file. This test shows how to use the function to list and run npm scripts using fzf.

--- a/test/makefile.bats
+++ b/test/makefile.bats
@@ -66,14 +66,24 @@ assert_links_to() {
 }
 
 @test "make dotfiles does not nest the link inside an existing real directory" {
-  skip "known bug, tracked in #260"
   mkdir -p "$FAKE_HOME/.vim/pack"
   run make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
   [ ! -e "$FAKE_HOME/.vim/.vim" ]
+  # The user's directory is left exactly as it was, and the skip is reported.
+  [ -d "$FAKE_HOME/.vim/pack" ]
+  [ ! -L "$FAKE_HOME/.vim" ]
+  [[ "$output" == *"skip $FAKE_HOME/.vim"* ]]
+}
+
+@test "make dotfiles replaces a symlinked directory rather than skipping it" {
+  ln -s /tmp "$FAKE_HOME/.vim"
+  run make -C "$REPO" dotfiles HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.vim" "$REPO/.vim"
 }
 
 @test "make dotfiles does not symlink repository tooling directories" {
-  skip "known bug, tracked in #260"
   make -C "$REPO" dotfiles HOME="$FAKE_HOME"
   [ ! -e "$FAKE_HOME/.devcontainer" ]
   [ ! -e "$FAKE_HOME/.vscode" ]
@@ -86,6 +96,16 @@ assert_links_to() {
   run make -C "$REPO" config HOME="$FAKE_HOME"
   [ "$status" -eq 0 ]
   assert_links_to "$FAKE_HOME/.config/nvim" "$REPO/.config/nvim"
+}
+
+@test "make config does not nest the link inside an existing real directory" {
+  mkdir -p "$FAKE_HOME/.config/nvim/lua"
+  run make -C "$REPO" config HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  [ ! -e "$FAKE_HOME/.config/nvim/nvim" ]
+  [ -d "$FAKE_HOME/.config/nvim/lua" ]
+  # Unaffected entries are still linked.
+  assert_links_to "$FAKE_HOME/.config/kitty" "$REPO/.config/kitty"
 }
 
 @test "make config succeeds when HOME/.config does not exist yet" {


### PR DESCRIPTION
Closes #260.

`ln -sfn` は、リンク先が**すでに実ディレクトリとして存在する**場合エラーにならず、そのディレクトリの中にリンクを作ります。つまり `~/.vim` や `~/.vscode` が既にある人にとって `make dotfiles` は何もしていないのに、**rc=0 で成功扱い**になっていました。

方針は issue に書いた C + A の組み合わせです。

## 変更内容

### 1. リポジトリ用ディレクトリを `IGNORE` に追加

```make
IGNORE := ... .config .devcontainer .vscode
```

`.devcontainer` と `.vscode` はこのリポジトリの設定であって `$HOME` には不要です。とくに `~/.vscode` は **VSCode の拡張機能ディレクトリ**で名前が衝突しているだけなので、貼らないのが正しい扱いです。

### 2. 残りは「既存の実ディレクトリなら警告して skip」

```make
define link
if [ -d "$(2)" ] && [ ! -L "$(2)" ]; then echo "skip $(2): already a directory, remove or rename it to link"; else ln -sfnv "$(1)" "$(2)"; fi;
endef
```

- **実ディレクトリ** → 触らずに skip し、理由と対処を出力する。人のディレクトリを勝手に消したり退避したりはしない
- **ディレクトリへの symlink** → 従来どおり張り替える（自分が前回作ったリンクの更新）
- **通常ファイル** → 従来どおり上書きする。素の `~/.bashrc` を置き換えるのが本来の目的なので、ここは変えていません

`dotfiles` と `config` の両方に適用しました。`~/.config/nvim` が実ディレクトリのときも同じ入れ子が起きていたためです。

## 動作確認

- `bats test/makefile.bats` → **16/16 pass、skip ゼロ**（#262 で仕込んだ残りの skip を解除し、`make config` 版と「symlink なら張り替える」ケースを追加）
- `~/.vim/pack` がある状態で `make dotfiles` → 入れ子なし、`.vim/pack` はそのまま、skip メッセージあり、rc=0
- `~/.config/nvim/lua` がある状態で `make config` → nvim は skip、他のエントリは正常にリンク
- `make` の出力に `if [ ... ]` の中身が漏れていないことを確認（`define` 展開時のエコー対策）

## 補足

すでに旧版の `make` を実行して `~/.vscode` に symlink ができている場合、`.vscode` が `TARGET` から外れたことで `make unlink` の対象からも外れます。残っていたら手で消してください。

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_