### PR TITLE
docs: make zsh the documented source of truth, realign fish aliases

### DIFF
--- a/.config/fish/conf.d/aliases.fish
+++ b/.config/fish/conf.d/aliases.fish
@@ -1,4 +1,7 @@
-alias get_default_branch="git remote show origin | grep 'HEAD branch' | cut -d ':' -f2 | sed 's/[ ]//g'"
+# NOTE: .zshrc is the source of truth for these. See README.md -- when an alias
+# exists in both shells it must behave identically here.
+
+alias get_default_branch="git remote show origin | grep 'HEAD branch' | awk '{print \$3}'"
 alias git_current_branch="git branch | grep \* | cut -d ' ' -f2"
 
 #alias for peco
@@ -38,7 +41,7 @@ alias gsu="git stash -u"
 alias bl="git branch"
 alias branch="git branch"
 alias pull="git pull"
-alias up="git pull upstream master"
+alias up="git stash -u && git rebase main && git stash pop"
 
 # git functions
 
@@ -65,9 +68,7 @@ alias yl="yarn lint"
 alias ytc="yarn type-check"
 alias build="yarn build"
 alias start="yarn start"
-alias lint="yarn lint"
 alias type-check="yarn type-check"
-alias tc="yarn type-check"
 alias ybuild="yarn build"
 alias ystart="yarn start"
 alias ylint="yarn lint"
@@ -76,10 +77,14 @@ alias ybt="yarn bootstrap"
 alias yarnstrap="yarn bootstrap"
 alias yad="yarn add -D"
 alias ya="yarn add"
-alias add="yarn add"
-alias addd="yarn add -D"
 alias yag="yarn global add"
-alias addg="yarn global add"
+
+# pnpm
+alias add="pnpm add"
+alias addd="pnpm add -D"
+alias addg="pnpm global add"
+alias lint="pnpm lint"
+alias tc="pnpm type-check"
 alias yw="yarn watch"
 alias ytest="yarn test"
 alias yyb="yarn && yarn bootstrap"
@@ -113,12 +118,12 @@ end
 alias ch="hub browse && code ."
 
 # alias to run android emulator
-alias emulaor="$HOME/Library/Android/sdk/emulator/emulator"
-alias listdroid='emulator -list-avds'
+set -gx EMULATOR "$HOME/Library/Android/sdk/emulator/emulator"
+alias listdroid='$EMULATOR -list-avds'
 
 # open selected android emulator
 function rundroid
-  emulator -avd (listdroid | peco)
+  $EMULATOR -avd (listdroid | peco)
 end
 
 # alias to copy file or folder to dotfiles repository
@@ -141,9 +146,6 @@ alias dkill="docker kill"
 
 # alias for ripgrep
 alias rgi="rg --no-ignore"
-
-# alias for clear
-alias cl="clear"
 
 # alias for exit
 alias .exit="exit"

--- a/.zshrc
+++ b/.zshrc
@@ -477,12 +477,6 @@ alias dce="docker compose exec"
 # alias for ripgrep
 alias rgi="rg --no-ignore"
 
-# alias for clear
-alias cl="clear"
-
-# clasp
-alias cl="clasp"
-
 # tmux
 alias tsa="tmux-send-all"
 alias pn="tmux-pane-name"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ This is a cross-platform dotfiles repo (macOS, Linux/WSL, Windows). The core mec
 ### Key files
 - `.zshrc` — main shell config; defines aliases, functions, PATH setup, keybindings. OS-specific blocks use `uname` detection (Darwin/Linux/Msys)
 - `.config/nvim/` — Neovim config using LazyVim framework (`config/lazy.lua` bootstraps lazy.nvim, plugins in `lua/plugins/`)
-- `.config/fish/` — Fish shell config (alternative shell)
+- `.config/fish/` — Fish shell config (experimental, best-effort). `.zshrc` is the source of truth for aliases and functions; fish carries only a subset. An alias defined in both shells must behave identically — add it to `.zshrc` first
 - `configs/.vscode/` — VSCode settings, keybindings, and extension sync script
 - `.scripts/` — custom CLI tools added to PATH (`duck`, `google`, `pmux`, `git-worktree-pull`)
 - `powershell/` — komorebi window manager start/stop scripts

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Run `bootstrap.ps1` to setup configuration for PowerShell
 ./bootstrap.ps1
 ```
 
+## Shells
+
+**zsh (`.zshrc`) is the source of truth.** It is the shell this repo is built around: it is what `install.sh` sets up, what CI lints (`zsh -n` plus a full `source`), and where every alias, function and keybinding lands first.
+
+`.config/fish/` is **experimental** and maintained on a best-effort basis. It carries a subset of the zsh aliases and none of the more involved functions (`run-script`, `peco-workspace`, `fzf-workspace`, …). Fish is not installed by `install.sh` and is not in the `Brewfile`.
+
+If you touch aliases:
+
+- Add or change them in `.zshrc` first.
+- Porting to fish is optional — but **an alias that exists in both shells must behave identically**. A name that means one thing in zsh and another in fish is worse than not having it in fish at all.
+
 ## Scripts
 
 `.scripts/` is symlinked into `$HOME` by `make` and added to `PATH` by `.zshrc`.


### PR DESCRIPTION
Closes #242.

issue の選択肢のうち **A（zsh を source of truth と明記する）** を採りました。あわせて、実際に挙動が食い違っていた fish 側のエイリアスを zsh に揃えています。

## 実測したズレ

| | zsh | fish |
| --- | --- | --- |
| エイリアス数 | 133 | 79 |
| fish にしか無い | — | 13 |
| **同名で中身が違う** | **10** | |

とくに危なかったもの:

| | zsh | fish |
| --- | --- | --- |
| `up` | `git stash -u && git rebase main && git stash pop` | `git pull upstream master` |
| `cl` | `clasp` | `clear` |
| `add` / `addd` / `addg` / `lint` / `tc` | `pnpm ...` | `yarn ...` |
| `get_default_branch` | `awk '{print $3}'` 版 | `cut`+`sed` 版 |
| `listdroid` | `$EMULATOR -list-avds` | `emulator -list-avds`（PATH 依存） |

`up` と `cl` は完全に別のコマンドなので、シェルを行き来すると事故ります。fish 側は全体的に古く、zsh が pnpm / `main` に移行したあと追従できていませんでした。

なお **fish は `Brewfile` にも `install.sh` にも README にも登場しません**（参照は CLAUDE.md の 1 行のみ）。実態として zsh が主で fish が従なので、それを明文化する形にしています。

## 変更内容

### ドキュメント

- **README.md** — `## Shells` セクションを新設。zsh が source of truth、fish は experimental / best-effort であること、そして **「両方に存在するエイリアスは同じ挙動でなければならない」** というルールを明記
- **CLAUDE.md** — `.config/fish/` の説明を同じ趣旨に更新

### `.config/fish/conf.d/aliases.fish`

- `up`、`add` / `addd` / `addg` / `lint` / `tc`、`get_default_branch` を zsh の定義に合わせた
- yarn 系（`ya` / `yad` / `yag` など fish 固有のもの）はそのまま残し、pnpm 系は独立したブロックに分離
- Android emulator まわりを zsh と同じ `$EMULATOR` 経由に統一し、タイポの `alias emulaor` を削除
- 先頭に「zsh が正」である旨のコメントを追加

### `cl` を両シェルから削除

使っていないエイリアスだったため、まとめて削除しました。`.zshrc` 側は二重定義になっていて、

```
481:alias cl="clear"     # 「# alias for clear」ブロック
484:alias cl="clasp"     # 「# clasp」ブロック
```

後勝ちで実質 `clasp`、`clear` のほうは死んでいる状態でした。fish は `clear`。`clasp`（Google Apps Script CLI）はもう使っていないとのことなので、両方まとめて落としています。リポジトリ内に `clasp` への他の参照はありません。

## 動作確認

- `zsh -n .zshrc` → OK、`zsh -c "source ./.zshrc"` → OK
- `fish -n .config/fish/conf.d/aliases.fish` → OK
- fish で実際に source して、`up` / `add` / `addd` / `addg` / `lint` / `tc` / `get_default_branch` / `listdroid` / `rundroid` が意図した定義に解決されることを確認
- `get_default_branch` を fish 上で実行して `master` が返ることを確認（zsh 版と同じ結果）
- `.zshrc` 内に重複定義されたエイリアスがもう無いことを確認
- 再計測の結果、挙動が食い違うエイリアスは `..` のみ（zsh `cd ../` / fish `cd ..`、挙動は同一）