### PR TITLE
ci: fail the build when zsh and fish aliases disagree

### DIFF
--- a/.config/fish/conf.d/aliases.fish
+++ b/.config/fish/conf.d/aliases.fish
@@ -135,7 +135,7 @@ function n
   yarn (cat package.json | jq .scripts |  sed '1d' | sed '$d' | pf | sed 's/: ".*".//g' | sed 's/"//g' | sed 's/[ ]//g');
 end
 
-alias ..='cd ..'
+alias ..='cd ../'
 alias ....='cd ../..'
 alias ......='cd ../../..'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y bats lsof tmux
       - name: Run script tests
         run: bats test/scripts.bats
+      # Keeps the shells from drifting apart again: .zshrc is the source of
+      # truth, and an alias present in both must mean the same thing.
+      - name: Run alias tests
+        run: bats test/aliases.bats
 
   gitleaks:
     runs-on: ubuntu-latest

--- a/test/README.md
+++ b/test/README.md
@@ -13,6 +13,15 @@ brew install bats-core
 bats test/scripts.bats
 ```
 
+### aliases.bats
+
+Automated [bats-core](https://github.com/bats-core/bats-core) tests that keep `.zshrc` and `.config/fish/` from drifting apart. They enforce the rule documented in the root `README.md`: `.zshrc` is the source of truth, and an alias defined in **both** shells must expand to the same thing. Fish is not required to carry every zsh alias — only to agree on the ones it does carry. A second check catches an alias defined twice in `.zshrc`, where the later definition silently wins. These run in CI on every push; locally:
+
+```bash
+brew install bats-core
+bats test/aliases.bats
+```
+
 ### makefile.bats
 
 Automated [bats-core](https://github.com/bats-core/bats-core) tests for the symlink targets in the `Makefile` (`dotfiles`, `config`, `claude`, `unlink`, `list`, `help`). Each test points `HOME` at a throwaway directory, so a fresh machine is reproduced without touching the real one, and asserts on the symlinks that were actually produced — `ln -sfn` can fail in ways that still leave `make` green. These run in CI on both macOS and Linux; locally:

--- a/test/aliases.bats
+++ b/test/aliases.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+# Guards the rule documented in README.md: .zshrc is the source of truth, and an
+# alias that exists in both shells must behave identically. Nothing here asks
+# fish to carry every zsh alias -- only that the ones it does carry agree, so
+# `up` never means one thing in zsh and another in fish again.
+#
+# Run locally with `bats test/aliases.bats` (brew install bats-core).
+
+ZSHRC="$BATS_TEST_DIRNAME/../.zshrc"
+FISH_ALIASES="$BATS_TEST_DIRNAME/../.config/fish/conf.d/aliases.fish"
+
+# Print "name<TAB>definition" for every `alias name=...` line in $1. The
+# surrounding quotes and any trailing comment are stripped so that the two
+# shells can be compared as plain text regardless of quoting style.
+alias_defs() {
+  grep -E "^[[:space:]]*alias [A-Za-z0-9_.:-]+=" "$1" |
+    sed -E "s/^[[:space:]]*alias[[:space:]]+//" |
+    sed -E "s/^([A-Za-z0-9_.:-]+)=/\1\t/" |
+    sed -E "s/\t['\"]/\t/; s/['\"][[:space:]]*(#.*)?\$//"
+}
+
+# Guard against the extraction silently matching nothing, which would make
+# every other check in this file pass for the wrong reason.
+@test "alias extraction finds the aliases in both shells" {
+  [ "$(alias_defs "$ZSHRC" | wc -l)" -gt 50 ]
+  [ "$(alias_defs "$FISH_ALIASES" | wc -l)" -gt 30 ]
+  [[ "$(alias_defs "$ZSHRC")" == *"gst"$'\t'"git status"* ]]
+  [[ "$(alias_defs "$FISH_ALIASES")" == *"gst"$'\t'"git status"* ]]
+}
+
+@test "no alias is defined more than once in .zshrc" {
+  dupes="$(alias_defs "$ZSHRC" | cut -f1 | sort | uniq -d)"
+  if [ -n "$dupes" ]; then
+    echo "these aliases are defined twice; the later one silently wins:"
+    echo "$dupes"
+    false
+  fi
+}
+
+@test "an alias defined in both shells means the same thing" {
+  conflicts="$(join -t$'\t' \
+    <(alias_defs "$ZSHRC" | sort -u -t$'\t' -k1,1) \
+    <(alias_defs "$FISH_ALIASES" | sort -u -t$'\t' -k1,1) |
+    awk -F'\t' '$2 != $3 { printf "%s\n  zsh:  %s\n  fish: %s\n", $1, $2, $3 }')"
+  if [ -n "$conflicts" ]; then
+    echo "these aliases disagree between the shells (.zshrc is the source of truth):"
+    echo "$conflicts"
+    false
+  fi
+}


### PR DESCRIPTION
#265 のフォローアップ。

#265 で「`.zshrc` が source of truth、両方のシェルに存在するエイリアスは同じ挙動でなければならない」というルールを README に書きましたが、**それを強制する仕組みがありません**でした。`up` / `cl` / yarn→pnpm 系がズレていったのはまさにそこが原因なので、チェックを足します。

## 変更内容

### `test/aliases.bats`（新規・3 テスト）

`.zshrc` と `.config/fish/conf.d/aliases.fish` からエイリアス定義を抽出して比較します。

| テスト | 内容 |
| --- | --- |
| 抽出が機能しているか | 抽出結果が空でないこと、既知のエイリアスが両シェルで取れることを確認。**正規表現が壊れて「違反ゼロ」に見える事故を防ぐガード** |
| `.zshrc` 内の二重定義 | 同じ名前が 2 回定義されていたら落とす（後勝ちで前が黙って死ぬため。`cl` がこれだった） |
| シェル間の不一致 | 両方に存在する名前で定義が違ったら落とす |

fish が zsh の全エイリアスを持つ必要はありません。**持っているものだけ一致していればいい**、という緩い制約にしています。引用符のスタイル差（`'` と `"`）と行末コメントは正規化して比較します。

### `.github/workflows/lint.yml`

既存の `bats` ジョブに `bats test/aliases.bats` を追加。

### `.config/fish/conf.d/aliases.fish`

`..` を `cd ..` → `cd ../` に。zsh 側に合わせただけで**挙動は同一**です。これで違反ゼロの状態からスタートできます。

### `test/README.md`

新テストの説明を追記。

## 動作確認

- `bats test/aliases.bats` → 3/3 pass
- **わざとズレを入れて落ちることを確認**（これが無いとテストが無意味なので）:

  fish の `up` を昔の定義に戻した場合:
  ```
  not ok 3 an alias defined in both shells means the same thing
  # these aliases disagree between the shells (.zshrc is the source of truth):
  # up
  #   zsh:  git stash -u && git rebase main && git stash pop
  #   fish: git pull upstream master
  ```

  `.zshrc` に `cl` の二重定義を復活させた場合:
  ```
  not ok 2 no alias is defined more than once in .zshrc
  # these aliases are defined twice; the later one silently wins:
  # cl
  ```
- `zsh -n .zshrc` / `fish -n` → OK
- `actionlint` → clean
- `bats test/aliases.bats test/makefile.bats` → 19/19 pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_