### PR TITLE
fix(fish): drop starship, load asdf from ~/.asdf, and document setup

### DIFF
--- a/.config/fish/conf.d/rustup.fish
+++ b/.config/fish/conf.d/rustup.fish
@@ -1,1 +1,1 @@
-. "$HOME/.cargo/env.fish"
+test -f "$HOME/.cargo/env.fish"; and . "$HOME/.cargo/env.fish"

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -1,6 +1,3 @@
-# Starship
-starship init fish | source
-
 # Ruby
 set -gx PATH $HOME/Software/ruby $PATH
 set -gx PATH $HOME/Software/ruby/bin $PATH
@@ -29,5 +26,8 @@ set -gx PATH $ANDROID_HOME/emulator $PATH
 # opam configuration
 source $HOME/.opam/opam-init/init.fish > /dev/null 2> /dev/null || true
 
-# asdf version manager
-source /usr/local/opt/asdf/asdf.fish
+# asdf version manager. install.sh clones asdf to ~/.asdf and .zshrc sources it
+# from there, so keep fish on the same install rather than a Homebrew prefix.
+if test -f $HOME/.asdf/asdf.fish
+    source $HOME/.asdf/asdf.fish
+end

--- a/README.md
+++ b/README.md
@@ -50,6 +50,38 @@ If you touch aliases:
 - Add or change them in `.zshrc` first.
 - Porting to fish is optional — but **an alias that exists in both shells must behave identically**. A name that means one thing in zsh and another in fish is worse than not having it in fish at all.
 
+`test/aliases.bats` enforces that in CI, and also fails if an alias is defined twice in `.zshrc` (where the later definition silently wins).
+
+### Setting up fish
+
+Fish is opt-in. `install.sh` does not touch it and it is deliberately absent from the `Brewfile`.
+
+1. **Install fish.**
+
+   ```bash
+   brew install fish            # macOS
+   sudo apt-get install fish    # Debian/Ubuntu/WSL
+   ```
+
+2. **Symlink the config.** `.config/fish/` is picked up by the existing target — no fish-specific step:
+
+   ```bash
+   make config
+   ```
+
+3. **Optionally make it your login shell.** zsh remains the shell this repo is built around, so this is a deliberate choice, not part of setup:
+
+   ```bash
+   echo "$(command -v fish)" | sudo tee -a /etc/shells
+   chsh -s "$(command -v fish)"
+   ```
+
+That is the whole setup — everything else fish needs is either already in the repo or shared with zsh:
+
+- **No plugin-manager step.** The `fisher` plugins listed in `.config/fish/fishfile` (`plugin-asdf`, `plugin-peco`, `plugin-balias`, `fish-nvm`) are vendored under `.config/fish/functions/` and `.config/fish/conf.d/`, so they arrive with the symlink.
+- **No extra packages.** `peco` and `fzf` come from the `Brewfile`. Fish uses its own default prompt rather than a separate prompt tool.
+- **asdf, rustup and opam are optional.** `config.fish` picks up asdf from the `~/.asdf` clone `install.sh` creates — the same install `.zshrc` uses — and each of the three is guarded, so fish starts cleanly whether or not they are present.
+
 ## Scripts
 
 `.scripts/` is symlinked into `$HOME` by `make` and added to `PATH` by `.zshrc`.


### PR DESCRIPTION
#265 / #266 のフォローアップ。fish の起動時エラーを潰したうえで、セットアップ手順を README に追記します。

当初は手順を書くだけの PR でしたが、書くために実機で起動したところ **3 つのエラーが必ず出る**ことが分かったため、そちらも直しています。「エラーが出ますが無視してください」と書いた手順書を残すより、エラー自体を無くすほうが良いと判断しました。

## 直したもの

### 1. asdf のパスが全環境で間違っていた

```fish
source /usr/local/opt/asdf/asdf.fish
```

これは **Intel Homebrew のパス**で、以下のどれとも一致しません。

- Apple Silicon の Homebrew（`/opt/homebrew/...`）
- `install.sh` が作る `~/.asdf` クローン（`.zshrc` もこれを見ている）

このリポジトリは asdf を **`~/.asdf`（git clone, v0.13.1）で統一**しているので、fish もそこを見るようにし、存在確認のガードを付けました。

### 2. starship を削除

```fish
# Starship
starship init fish | source
```

調べたところ、**リポジトリ内で starship を使っているのは fish のこの 1 行だけ**でした。

- `.zshrc` は `vcs_info` を使った自前の `PROMPT=` を組んでいる（`.zshrc:169`）
- starship は `Brewfile` にも入っていない

つまり誰も入れていないツールを毎回呼んでいて、`fish: Unknown command: starship` を出すだけの状態でした。削除して、fish は標準のプロンプトを使います。

### 3. rustup の source にガードを追加

`conf.d/rustup.fish` が `~/.cargo/env.fish` を無条件で読んでいたので、存在確認を付けました。

## 追記したドキュメント

`## Shells` に `### Setting up fish` を新設。手順は 3 つだけです。

1. `brew install fish` / `sudo apt-get install fish`
2. **`make config`** — `.config/fish/` は既存ターゲットで symlink されるので fish 専用の手順は不要
3. ログインシェルにするかは任意

あわせて「これ以上やることは無い」根拠として、fisher の実行が不要なこと（4 プラグインはベンダリング済み）、追加パッケージが不要なこと、asdf / rustup / opam がすべて任意であることを明記しました。

## 動作確認

まっさらな `$HOME` に対して:

- **依存が何も無い状態で fish を起動 → エラー出力ゼロ**（修正前は 3 件）
- `~/.asdf/asdf.fish` を置くと読まれることを確認（変数がセットされる）
- `~/.cargo/env.fish` を置くと読まれることを確認
- `make config` で `~/.config/fish` が張られ、`gst` / `up` / `pf` が意図した定義に解決されること
- `fish -n` → config.fish / rustup.fish / aliases.fish すべて OK
- `bats test/aliases.bats` → 3/3 pass