### PR TITLE
feat(zsh): show repo, worktree and path-from-root in the prompt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,14 +41,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install bats, lsof and tmux
-        run: sudo apt-get update && sudo apt-get install -y bats lsof tmux
+      - name: Install bats, lsof, tmux and zsh
+        run: sudo apt-get update && sudo apt-get install -y bats lsof tmux zsh
       - name: Run script tests
         run: bats test/scripts.bats
       # Keeps the shells from drifting apart again: .zshrc is the source of
       # truth, and an alias present in both must mean the same thing.
       - name: Run alias tests
         run: bats test/aliases.bats
+      # zsh -n only checks syntax; these check what the prompt actually renders.
+      - name: Run prompt tests
+        run: bats test/prompt.bats
 
   gitleaks:
     runs-on: ubuntu-latest

--- a/.zshrc
+++ b/.zshrc
@@ -159,6 +159,41 @@ zstyle ':vcs_info:*' actionformats '[%b|%a]'
 
 setopt prompt_subst
 
+### プロンプトのパス表示
+# git リポジトリの中では絶対パスではなく <repo>[/<worktree>] とリポジトリルート
+# からの相対パスを出す。~/.ghq/github.com/owner/... のようなパスは頭が長いだけで
+# 実際に知りたいのはリポジトリ名・worktree 名・ルートからの位置なので。
+# ブランチ名は vcs_info 側が出す。リポジトリ外では従来どおりフルパス表示。
+_prompt_path() {
+  local -a gi
+  gi=(${(f)"$(command git rev-parse --show-toplevel --git-common-dir 2>/dev/null)"})
+
+  local out
+  if (( ${#gi} != 2 )); then
+    out=${PWD/#$HOME/\~}
+  else
+    # --git-common-dir はサブディレクトリだと相対で返るので :a で絶対化する
+    local root=${gi[1]} common=${gi[2]:a}
+
+    # common dir が .git / .bare ならそれはリポジトリ内の隠しディレクトリなので
+    # 親がリポジトリ名 (通常の clone、および <repo>/.bare + <repo>/<branch> 運用)。
+    # そうでなければ common dir 自体が bare リポジトリ (foo.git など) なので、
+    # .git サフィックスを落としたものがリポジトリ名になる。
+    local label
+    case ${common:t} in
+      .git | .bare) label=${common:h:t} ;;
+      *)            label=${${common:t}%.git} ;;
+    esac
+    # linked worktree では <root>/.git がディレクトリではなくファイルになる
+    [[ -f $root/.git ]] && label+="/${root:t}"
+    out="${label}${PWD#$root}"
+  fi
+
+  # prompt_subst で展開した中身は % がプロンプトエスケープとして再解釈されるため、
+  # ディレクトリ名に % が含まれていてもプロンプトが壊れないようにエスケープする
+  _prompt_path_msg="${out//\%/%%}"
+}
+
 ### SSH接続時はプロンプト先頭に目立つバッジを表示する
 if [[ -n "$SSH_CONNECTION" || -n "$SSH_TTY" ]]; then
   SSH_INDICATOR=$'%K{magenta}%F{white} SSH:%m %f%k\n'
@@ -166,7 +201,7 @@ else
   SSH_INDICATOR=""
 fi
 
-PROMPT="${SSH_INDICATOR}%F{green}╭─ %~ %f"'${vcs_info_msg_0_}'"
+PROMPT="${SSH_INDICATOR}%F{green}╭─ "'${_prompt_path_msg}'" %f"'${vcs_info_msg_0_}'"
 %F{green}╰─%B$%b %f"
 
 # Uncomment the following line to display red dots whilst waiting for completion.
@@ -561,9 +596,10 @@ asdf_update_java_home() {
   fi
 }
 
-precmd() { 
-  asdf_update_java_home; 
+precmd() {
+  asdf_update_java_home;
   vcs_info;
+  _prompt_path;
 }
 
 # bun completions

--- a/test/README.md
+++ b/test/README.md
@@ -13,6 +13,15 @@ brew install bats-core
 bats test/scripts.bats
 ```
 
+### prompt.bats
+
+Automated [bats-core](https://github.com/bats-core/bats-core) tests for `_prompt_path` in `.zshrc`, which replaces the working directory in the prompt with `<repo>[/<worktree>]` plus the path from the repository root. Each test covers one of the things the logic is easy to get wrong: `--git-common-dir` coming back relative from a subdirectory, detecting a linked worktree by `<root>/.git` being a file, and doubling `%` so a directory name cannot corrupt the prompt. The function is pulled out of `.zshrc` on its own, so the rest of the file does not have to be loadable. Needs `zsh`; these run in CI on every push. Locally:
+
+```bash
+brew install bats-core
+bats test/prompt.bats
+```
+
 ### aliases.bats
 
 Automated [bats-core](https://github.com/bats-core/bats-core) tests that keep `.zshrc` and `.config/fish/` from drifting apart. They enforce the rule documented in the root `README.md`: `.zshrc` is the source of truth, and an alias defined in **both** shells must expand to the same thing. Fish is not required to carry every zsh alias — only to agree on the ones it does carry. A second check catches an alias defined twice in `.zshrc`, where the later definition silently wins. These run in CI on every push; locally:

--- a/test/prompt.bats
+++ b/test/prompt.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+
+# Tests for _prompt_path in .zshrc, which decides what the prompt shows in
+# place of the working directory. The logic has three easy things to get wrong,
+# so each one has a case here:
+#   - `git rev-parse --git-common-dir` returns a *relative* path from a
+#     subdirectory, so it has to be made absolute before the repo name is taken
+#   - a linked worktree is identified by <root>/.git being a file, not a
+#     directory; comparing --git-dir against --git-common-dir gives a false
+#     positive in any subdirectory
+#   - text substituted into the prompt is re-scanned for % escapes, so a `%` in
+#     a directory name corrupts the prompt unless it is doubled
+#
+# Run locally with `bats test/prompt.bats` (needs zsh and bats-core).
+
+ZSHRC="$BATS_TEST_DIRNAME/../.zshrc"
+
+setup() {
+  command -v zsh >/dev/null || skip "zsh not available"
+  WORK="$(mktemp -d)"
+  git init -q "$WORK/myrepo"
+  git -C "$WORK/myrepo" config user.email t@example.com
+  git -C "$WORK/myrepo" config user.name test
+  mkdir -p "$WORK/myrepo/src/components"
+  git -C "$WORK/myrepo" add -A
+  git -C "$WORK/myrepo" commit -qm init --allow-empty
+}
+
+teardown() {
+  [ -n "${WORK:-}" ] && rm -rf "$WORK"
+}
+
+# Run the real _prompt_path from .zshrc inside $1 and print what the prompt
+# would contain. Only the function is pulled out, so the rest of .zshrc (asdf,
+# plugins, PATH setup) does not have to be loadable here.
+prompt_path_in() {
+  (
+    cd "$1" || return 1
+    zsh -c "
+      $(sed -n '/^_prompt_path() {/,/^}$/p' "$ZSHRC")
+      _prompt_path
+      print -r -- \$_prompt_path_msg
+    "
+  )
+}
+
+@test "outside a git repository the full path is shown" {
+  run prompt_path_in "$WORK"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$WORK" ]
+}
+
+@test "at a repository root only the repository name is shown" {
+  run prompt_path_in "$WORK/myrepo"
+  [ "$status" -eq 0 ]
+  [ "$output" = "myrepo" ]
+}
+
+@test "in a subdirectory the path is relative to the repository root" {
+  run prompt_path_in "$WORK/myrepo/src/components"
+  [ "$status" -eq 0 ]
+  [ "$output" = "myrepo/src/components" ]
+}
+
+@test "a linked worktree shows repository and worktree name" {
+  git -C "$WORK/myrepo" worktree add -q "$WORK/wt" -b feature
+  run prompt_path_in "$WORK/wt"
+  [ "$status" -eq 0 ]
+  [ "$output" = "myrepo/wt" ]
+}
+
+@test "a subdirectory of a linked worktree keeps the repository name" {
+  git -C "$WORK/myrepo" worktree add -q "$WORK/wt" -b feature
+  mkdir -p "$WORK/wt/src"
+  run prompt_path_in "$WORK/wt/src"
+  [ "$status" -eq 0 ]
+  [ "$output" = "myrepo/wt/src" ]
+}
+
+@test "the bare-clone worktree layout resolves the repository name" {
+  # <proj>/.bare plus <proj>/main, which is what git-worktree-pull and pmux
+  # expect. The repository name has to come from the common dir, not from the
+  # parent of the current worktree.
+  mkdir -p "$WORK/proj"
+  git clone -q --bare "$WORK/myrepo" "$WORK/proj/.bare"
+  echo "gitdir: ./.bare" >"$WORK/proj/.git"
+  git -C "$WORK/proj" worktree add -q main 2>/dev/null || skip "worktree add unsupported here"
+
+  run prompt_path_in "$WORK/proj/main"
+  [ "$status" -eq 0 ]
+  [ "$output" = "proj/main" ]
+}
+
+@test "a bare clone named <repo>.git resolves the repository name" {
+  # The other bare convention: the bare repo *is* foo.git, with worktrees
+  # beside it. Here the common dir is the repository, so its parent is not the
+  # repository name -- the .git suffix has to be stripped instead.
+  git clone -q --bare "$WORK/myrepo" "$WORK/foo.git"
+  git -C "$WORK/foo.git" worktree add -q "$WORK/foo-wt" 2>/dev/null || skip "worktree add unsupported here"
+
+  run prompt_path_in "$WORK/foo-wt"
+  [ "$status" -eq 0 ]
+  [ "$output" = "foo/foo-wt" ]
+}
+
+@test "inside a bare repository the full path is shown" {
+  git clone -q --bare "$WORK/myrepo" "$WORK/foo.git"
+  # There is no working tree here, so there is no root to be relative to.
+  run prompt_path_in "$WORK/foo.git"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$WORK/foo.git" ]
+}
+
+@test "a percent sign in a directory name is escaped for the prompt" {
+  mkdir -p "$WORK/myrepo/we%20ird"
+  run prompt_path_in "$WORK/myrepo/we%20ird"
+  [ "$status" -eq 0 ]
+  # Doubled in the raw value so that prompt expansion renders a single %.
+  [ "$output" = "myrepo/we%%20ird" ]
+  rendered="$(zsh -c "setopt prompt_subst; p='$output'; print -rn -- \${(%%)p}")"
+  [ "$rendered" = "myrepo/we%20ird" ]
+}


### PR DESCRIPTION
プロンプトが作業ディレクトリのフルパスを出していましたが、`~/.ghq/github.com/Naturalclar/...` 以下ではその大半が固定の接頭辞で情報量がありません。git リポジトリの中では **リポジトリ名 / worktree 名 / ルートからの相対パス** を出すようにします。ブランチ名は従来どおり `vcs_info` が出すので変更なし。リポジトリの外では今までどおりフルパスです。

## 表示例

| 場所 | 変更前 | 変更後 |
| --- | --- | --- |
| リポジトリのルート | `~/.ghq/github.com/Naturalclar/dotfiles` | `dotfiles` |
| サブディレクトリ | `~/.ghq/github.com/Naturalclar/myrepo/src/components` | `myrepo/src/components` |
| linked worktree | `~/.ghq/github.com/Naturalclar/proj/main/src` | `proj/main/src` |
| リポジトリ外 | `~/foo/bar` | `~/foo/bar`（変更なし） |

```
╭─ dotfiles [master]
╰─$

╭─ proj/main/src [master]
╰─$
```

## bare clone 運用の扱い

リポジトリ名は **`--git-common-dir` から**決めています。現在の worktree の親ディレクトリではありません。bare clone には流儀が複数あるため、両方に対応しています。

- common dir が `.bare` / `.git`（リポジトリ内の隠しディレクトリ）→ **親ディレクトリ名**がリポジトリ名
- common dir がそれ以外（`foo.git` のように bare リポジトリ自身）→ **自身の名前から `.git` を落としたもの**

実際に検証したレイアウト:

| レイアウト | 結果 |
| --- | --- |
| 通常の clone（ルート / サブディレクトリ） | `myrepo` / `myrepo/src/components` |
| 通常の clone + linked worktree | `myrepo/myrepo-wt` |
| `<proj>/.bare` + `<proj>/main`（`git-worktree-pull` / `pmux` 想定） | `proj/main` |
| `<proj>/.git`(bare) + `<proj>/main` | `proj/main` |
| `foo.git`(bare) + 兄弟の `foo-wt` | `foo/foo-wt` |
| bare リポジトリの中に cd | フルパス（working tree が無いので相対の基準が存在しない） |

最後から 2 つ目は当初の実装で `C/foo-wt`（親ディレクトリ名）になっていたのを、レビュー中の指摘で見つけて直しました。

`precmd` は既に `vcs_info` を呼んでいるので、そこに 1 行足すだけです。`git rev-parse` 1 回で済ませています。

## ハマりどころと回帰テスト

実装中に静かに壊れる箇所が 3 つあったので、`test/prompt.bats` で 9 ケース押さえました。

1. **`--git-common-dir` はサブディレクトリだと相対パスで返る**（`../../.git`）。絶対化しないとリポジトリ名がおかしくなる
2. **linked worktree の判定**。`--git-dir` と `--git-common-dir` の文字列比較だと、通常リポジトリのサブディレクトリで**誤検知**します（片方が相対で返るため）。`<root>/.git` がファイルかどうかで判定しています
3. **`prompt_subst` で展開した中身は `%` がプロンプトエスケープとして再解釈される**。`we%20ird` というディレクトリ名だと `%2F` が色エスケープになってプロンプトが壊れます。`%%` にエスケープして回避

いずれも**わざと壊して該当テストが落ちることを確認済み**です。たとえば 2 の判定を `--git-dir` 比較に戻すと:

```
not ok 3 in a subdirectory the path is relative to the repository root
#   `[ "$output" = "myrepo/src/components" ]' failed
```

`foo.git` レイアウトの対応を外すと:

```
not ok 7 a bare clone named <repo>.git resolves the repository name
#   `[ "$output" = "foo/foo-wt" ]' failed
```

テストは `.zshrc` から `_prompt_path` だけを抜き出して実行するので、asdf やプラグインなど `.zshrc` の他の部分が読める必要はありません。

## CI

`bats` ジョブに `zsh` のインストールと `bats test/prompt.bats` を追加。既存の `zsh -n` は構文しか見ないので、実際に何がレンダリングされるかはこれまで一切検証されていませんでした。

## 動作確認

- `bats test/prompt.bats` → 9/9 pass
- prompt / aliases / makefile 合わせて 28 pass、失敗 0
- `zsh -n ./.zshrc` および `zsh -c "source ./.zshrc"` → OK
- `actionlint` → clean
- 上表の 6 レイアウトすべてで、実際に `.zshrc` を読み込んで `PROMPT` をレンダリングして確認