### PR TITLE
docs: add AGENTS.md for Codex and other coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+This file provides guidance to coding agents (Codex, etc.) when working with code in this repository. It mirrors `CLAUDE.md` — keep the two in sync when updating either.
+
+## Commands
+
+- `make` or `make dotfiles` — symlink all dotfiles (`.??*` except `.git`, `.gitignore`, etc.) into `$HOME`
+- `make config` — symlink `.config/*` entries into `$HOME/.config/`
+- `make claude` — symlink `configs/claude/settings.json` to `~/.claude/settings.json` (Claude Code hooks etc.; machine-local state like `feedbackSurveyState` is intentionally not committed)
+- `make vscodeExtensions` — sync VSCode extensions via `configs/.vscode/vscodeSync.sh`
+- `make list` — show which dotfiles will be symlinked
+- `make help` — print all make targets
+- Windows setup: run `./bootstrap.ps1` to concatenate `windows/*.ps1` into the PowerShell `$PROFILE`
+
+## CI
+
+- **lint.yml** — checks `.zshrc` syntax with `zsh -n` and sources it on Ubuntu
+- **make.yml** — runs `make` on macOS
+
+## Architecture
+
+This is a cross-platform dotfiles repo (macOS, Linux/WSL, Windows). The core mechanism is simple: `make dotfiles` creates symlinks from this repo into `$HOME`.
+
+### Key files
+- `.zshrc` — main shell config; defines aliases, functions, PATH setup, keybindings. OS-specific blocks use `uname` detection (Darwin/Linux/Msys)
+- `.config/nvim/` — Neovim config using LazyVim framework (`config/lazy.lua` bootstraps lazy.nvim, plugins in `lua/plugins/`)
+- `.config/fish/` — Fish shell config (experimental, best-effort). `.zshrc` is the source of truth for aliases and functions; fish carries only a subset. An alias defined in both shells must behave identically — add it to `.zshrc` first
+- `configs/.vscode/` — VSCode settings, keybindings, and extension sync script
+- `.scripts/` — custom CLI tools added to PATH (`duck`, `google`, `pmux`, `git-worktree-pull`)
+- `powershell/` — komorebi window manager start/stop scripts
+- `ahk/` — AutoHotKey scripts (remap keys, language switching, shortcuts)
+- `keymaps/` — custom keyboard layout mappings
+- `.config/kitty/`, `.config/hypr/`, `.config/i3/`, `.config/waybar/` — terminal and WM configs
+
+### Key tools assumed installed
+- **ghq** — repository management (`ghq get`, `ghq list`)
+- **peco/fzf** — fuzzy selection (workspace switching, history, script selection)
+- **asdf** — version manager for Node.js, Java, etc.
+- **lazygit** — terminal git UI (aliased as `lg`)
+
+### Notable shell functions
+- `run-script` (alias `rs`, keybind `Ctrl+N`) — fzf-based package.json script selector; auto-detects package manager from lockfile
+- `peco-workspace` (alias `ws`, keybind `Ctrl+W`) — cd to ghq-managed repos via peco
+- `fzf-workspace` (alias `wf`, keybind `Ctrl+A`) — cd to ghq-managed repos via fzf with README preview
+- `peco-history-selection` (keybind `Ctrl+Z`) — search shell history
+
+### Testing
+Tests are in `test/`. Each subdirectory has a `package.json` for testing the `run-script` function:
+- `cd test/test-package-scripts && rs` — test basic script selection
+- `cd test/test-colon-scripts && rs` — test scripts with colons in names
+
+## Code Style
+
+- Match existing formatting in each file
+- Shell scripts: prefer POSIX-compatible syntax when possible
+- PowerShell scripts: follow Microsoft best practices
+- The `.zshrc` uses vi mode (`set -o vi`)
+
+## Environment Variables
+
+Secret API keys go in `~/.config/secrets/credentials.sh` (auto-sourced by `.zshrc`, gitignored).


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` so Codex (and other coding agents that read the AGENTS.md convention) get the same repo guidance as Claude Code.
- Content mirrors the current `CLAUDE.md` (commands, CI, architecture, code style, env vars), with the intro made agent-agnostic and a note to keep the two files in sync.

## Test plan
- [x] Verified every `make` target referenced in the file exists in the Makefile (notably `make claude` — an earlier draft had accidentally renamed it)
- [ ] CI (lint.yml, make.yml) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)