### PR TITLE
fix(fish): .scripts on PATH, UTF-8 locale, and function-aware drift check

### DIFF
--- a/.config/fish/conf.d/aliases.fish
+++ b/.config/fish/conf.d/aliases.fish
@@ -103,10 +103,10 @@ alias get="ghq get"
 # rimraf
 alias rimraf="rm -rf"
 
-# cd to ghq directories
+# cd to ghq directories. zsh's ws is peco-workspace, which uses plain peco --
+# not pf, which turns on the fuzzy filter.
 function ws
-  set repo (ghq list --full-path | pf)
-  cd $repo  
+  cd (ghq list --full-path | peco)
 end
 
 function fish_user_key_bindings

--- a/.config/fish/conf.d/locale.fish
+++ b/.config/fish/conf.d/locale.fish
@@ -1,0 +1,13 @@
+# NOTE: mirrors the locale block at the top of .zshrc, which is the source of
+# truth. Force a UTF-8 locale so multibyte (e.g. Japanese) renders over SSH
+# clients like Termius, which don't forward the locale Terminal.app sets
+# locally. Only export a locale that's actually generated -- stock WSL and
+# container images ship C.UTF-8 only, and setting an unavailable value makes
+# other tools warn on every start.
+for l in en_US.UTF-8 C.UTF-8
+    if locale -a 2>/dev/null | string match -qir '^'(string split -m1 . $l)[1]'\.utf-?8$'
+        set -gx LANG $l
+        set -gx LC_ALL $l
+        break
+    end
+end

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -1,3 +1,6 @@
+# Scripts (.zshrc does the same; .scripts is symlinked into $HOME by `make`)
+set -gx PATH $HOME/.scripts $PATH
+
 # Ruby
 set -gx PATH $HOME/Software/ruby $PATH
 set -gx PATH $HOME/Software/ruby/bin $PATH

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,12 @@ name: Check Zshrc syntax
 
 on: [push, pull_request]
 
+# push and pull_request both fire for a PR branch, so without this every commit
+# starts two identical sets of runs and a force-push leaves the old ones going.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     strategy:
@@ -38,6 +44,9 @@ jobs:
 
   bats:
     runs-on: ubuntu-latest
+    # These tests spawn shells; a shell that blocks on a read would otherwise
+    # hold the runner for hours. The whole job takes well under a minute.
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,9 @@ jobs:
       # zsh -n only checks syntax; these check what the prompt actually renders.
       - name: Run prompt tests
         run: bats test/prompt.bats
+      # .scripts on PATH and the UTF-8 locale both fail silently when missing.
+      - name: Run fish config tests
+        run: bats test/fish-config.bats
 
   gitleaks:
     runs-on: ubuntu-latest

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -2,8 +2,15 @@ name: Main workflow
 
 on: [push, pull_request]
 
+# push and pull_request both fire for a PR branch, so without this every commit
+# starts two identical sets of runs and a force-push leaves the old ones going.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    timeout-minutes: 10
     strategy:
       # Report both platforms even when one fails; the Makefile hits GNU vs BSD
       # differences (ln, mktemp) that are only visible per-OS.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Run `bootstrap.ps1` to setup configuration for PowerShell
 If you touch aliases:
 
 - Add or change them in `.zshrc` first.
-- Porting to fish is optional — but **an alias that exists in both shells must behave identically**. A name that means one thing in zsh and another in fish is worse than not having it in fish at all.
+- Porting to fish is optional — but **a name that exists in both shells must behave identically**. A name that means one thing in zsh and another in fish is worse than not having it in fish at all.
 
-`test/aliases.bats` enforces that in CI, and also fails if an alias is defined twice in `.zshrc` (where the later definition silently wins).
+`test/aliases.bats` enforces that in CI. It compares aliases textually, and — because a name can be an alias in one shell and a function in the other, where there is nothing to compare across two different syntaxes — it also requires any such pair to be listed in `KNOWN_EQUIVALENT` with a note saying it was checked by hand. A new mismatched pair therefore cannot appear unnoticed. It also fails if an alias is defined twice in `.zshrc` (where the later definition silently wins).
 
 The prompt is the one place where fish deliberately carries a copy of zsh logic: `.config/fish/functions/__prompt_path.fish` mirrors `_prompt_path` in `.zshrc`, and `__prompt_git_state.fish` mirrors the `vcs_info` zstyles. `test/prompt.bats` runs both implementations over the same repository layouts and fails if they disagree.
 

--- a/test/README.md
+++ b/test/README.md
@@ -13,6 +13,15 @@ brew install bats-core
 bats test/scripts.bats
 ```
 
+### fish-config.bats
+
+Automated [bats-core](https://github.com/bats-core/bats-core) tests for the parts of `.config/fish/` that mirror `.zshrc`: `.scripts` being on `PATH`, and the UTF-8 locale forcing that keeps multibyte output readable over SSH clients like Termius. Both fail silently when missing — the shell still starts, the scripts just are not there and text breaks — so each is asserted directly, with a stub `locale` used to vary which locales are available. A final test checks that fish and zsh pick the *same* locale from the same input. Needs `fish`; these run in CI on every push. Locally:
+
+```bash
+brew install bats-core
+bats test/fish-config.bats
+```
+
 ### prompt.bats
 
 Automated [bats-core](https://github.com/bats-core/bats-core) tests for `_prompt_path` in `.zshrc`, which replaces the working directory in the prompt with `<repo>[/<worktree>]` plus the path from the repository root. Each test covers one of the things the logic is easy to get wrong: `--git-common-dir` coming back relative from a subdirectory, detecting a linked worktree by `<root>/.git` being a file, and doubling `%` so a directory name cannot corrupt the prompt. The function is pulled out of `.zshrc` on its own, so the rest of the file does not have to be loadable. Needs `zsh`; these run in CI on every push. Locally:

--- a/test/aliases.bats
+++ b/test/aliases.bats
@@ -1,14 +1,32 @@
 #!/usr/bin/env bats
 
-# Guards the rule documented in README.md: .zshrc is the source of truth, and an
-# alias that exists in both shells must behave identically. Nothing here asks
+# Guards the rule documented in README.md: .zshrc is the source of truth, and a
+# name that exists in both shells must behave identically. Nothing here asks
 # fish to carry every zsh alias -- only that the ones it does carry agree, so
 # `up` never means one thing in zsh and another in fish again.
+#
+# A name can be an alias in one shell and a function in the other, in which case
+# there is nothing to compare textually -- fish and zsh do not share a syntax.
+# Those pairs have to be checked by hand and recorded in KNOWN_EQUIVALENT below,
+# so a *new* one cannot appear without someone looking at it.
 #
 # Run locally with `bats test/aliases.bats` (brew install bats-core).
 
 ZSHRC="$BATS_TEST_DIRNAME/../.zshrc"
-FISH_ALIASES="$BATS_TEST_DIRNAME/../.config/fish/conf.d/aliases.fish"
+FISH_DIR="$BATS_TEST_DIRNAME/../.config/fish"
+FISH_ALIASES="$FISH_DIR/conf.d/aliases.fish"
+
+# Verified by hand to behave the same in both shells despite being written
+# differently. Do not add a name here without checking it.
+#
+#   gbd       git branch -d $(git branch | pf)      -- command substitution syntax
+#   gcod      git switch $(get_default_branch)      -- command substitution syntax
+#   gpcb      git push origin $(git_current_branch) -- command substitution syntax
+#   rundroid  $EMULATOR -avd "$(listdroid | peco)"  -- command substitution syntax
+#   ws        zsh calls peco-workspace; fish inlines the same one-liner
+#   n         zsh calls list(); fish inlines it plus a trailing-space strip,
+#             because fish's (...) does not word-split the way zsh's $(...) does
+KNOWN_EQUIVALENT="gbd gcod gpcb n rundroid ws"
 
 # Print "name<TAB>definition" for every `alias name=...` line in $1. The
 # surrounding quotes and any trailing comment are stripped so that the two
@@ -18,6 +36,32 @@ alias_defs() {
     sed -E "s/^[[:space:]]*alias[[:space:]]+//" |
     sed -E "s/^([A-Za-z0-9_.:-]+)=/\1\t/" |
     sed -E "s/\t['\"]/\t/; s/['\"][[:space:]]*(#.*)?\$//"
+}
+
+# Every name a shell puts in front of the user: aliases plus functions. The
+# alias-only comparison misses whatever the other shell implements as a
+# function, which is how `ws` came to mean two different things.
+zsh_names() {
+  {
+    grep -oE "^[[:space:]]*alias [A-Za-z0-9_.:-]+=" "$ZSHRC" | sed -E 's/^[[:space:]]*alias //; s/=$//'
+    grep -oE "^[A-Za-z_][A-Za-z0-9_-]*\(\)" "$ZSHRC" | sed 's/()//'
+    grep -oE "^function [A-Za-z_][A-Za-z0-9_-]*" "$ZSHRC" | sed 's/^function //'
+  } | sort -u
+}
+
+fish_names() {
+  {
+    grep -hoE "^[[:space:]]*alias [A-Za-z0-9_.:-]+=" "$FISH_DIR"/conf.d/*.fish | sed -E 's/^[[:space:]]*alias //; s/=$//'
+    grep -hoE "^function [A-Za-z0-9_.:-]+" "$FISH_DIR"/conf.d/*.fish | sed 's/^function //'
+    basename -s .fish "$FISH_DIR"/functions/*.fish
+  } | sort -u
+}
+
+defined_as_alias() {
+  case "$1" in
+    zsh) grep -qE "^[[:space:]]*alias $2=" "$ZSHRC" ;;
+    fish) grep -qhE "^[[:space:]]*alias $2=" "$FISH_DIR"/conf.d/*.fish ;;
+  esac
 }
 
 # Guard against the extraction silently matching nothing, which would make
@@ -46,6 +90,50 @@ alias_defs() {
   if [ -n "$conflicts" ]; then
     echo "these aliases disagree between the shells (.zshrc is the source of truth):"
     echo "$conflicts"
+    false
+  fi
+}
+
+@test "name extraction covers functions as well as aliases" {
+  # Without this the checks below can pass by finding nothing at all.
+  [ "$(zsh_names | wc -l)" -gt 100 ]
+  [ "$(fish_names | wc -l)" -gt 50 ]
+  # A function in each shell, which the alias-only extraction would miss.
+  zsh_names | grep -qx "run-script"
+  fish_names | grep -qx "gcod"
+}
+
+@test "a name defined in both shells is comparable or known-equivalent" {
+  unreviewed=""
+  for name in $(comm -12 <(zsh_names) <(fish_names)); do
+    # Both aliases: the test above already compares them textually.
+    if defined_as_alias zsh "$name" && defined_as_alias fish "$name"; then
+      continue
+    fi
+    case " $KNOWN_EQUIVALENT " in
+      *" $name "*) continue ;;
+    esac
+    unreviewed="$unreviewed $name"
+  done
+
+  if [ -n "$unreviewed" ]; then
+    echo "these names exist in both shells but are implemented differently, so"
+    echo "they cannot be compared as text. Check that each behaves the same and"
+    echo "add it to KNOWN_EQUIVALENT with a note, or make both sides aliases:"
+    for name in $unreviewed; do echo "  $name"; done
+    false
+  fi
+}
+
+@test "KNOWN_EQUIVALENT has no stale entries" {
+  # Keeps the list from silently outliving the names it excuses.
+  shared="$(comm -12 <(zsh_names) <(fish_names))"
+  stale=""
+  for name in $KNOWN_EQUIVALENT; do
+    echo "$shared" | grep -qx "$name" || stale="$stale $name"
+  done
+  if [ -n "$stale" ]; then
+    echo "KNOWN_EQUIVALENT lists names that are no longer in both shells:$stale"
     false
   fi
 }

--- a/test/fish-config.bats
+++ b/test/fish-config.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+# Tests for the parts of .config/fish/ that mirror .zshrc: the PATH entry for
+# .scripts, and the UTF-8 locale forcing. Both were missing from fish and are
+# invisible when broken -- the shell still starts, the scripts just are not
+# there and multibyte output silently breaks over SSH.
+#
+# Run locally with `bats test/fish-config.bats` (needs fish and bats-core).
+
+REPO="$BATS_TEST_DIRNAME/.."
+FISH_DIR="$BATS_TEST_DIRNAME/../.config/fish"
+
+setup() {
+  command -v fish >/dev/null || skip "fish not available"
+  WORK="$(mktemp -d)"
+}
+
+teardown() {
+  [ -n "${WORK:-}" ] && rm -rf "$WORK"
+}
+
+# Run fish with $HOME pointing at a throwaway directory that has .scripts
+# linked in, the way `make` sets it up.
+fish_with_home() {
+  ln -sfn "$(cd "$REPO" && pwd)/.scripts" "$WORK/.scripts"
+  HOME="$WORK" fish -c "source $FISH_DIR/config.fish 2>/dev/null; $1"
+}
+
+# Put a stub `locale` earlier on PATH so the available locales can be varied.
+stub_locale() {
+  mkdir -p "$WORK/bin"
+  {
+    echo '#!/bin/sh'
+    printf "printf '%s\\\\n'\n" "$1"
+  } >"$WORK/bin/locale"
+  chmod +x "$WORK/bin/locale"
+}
+
+# --- .scripts on PATH (#271) -------------------------------------------------
+
+@test "fish puts .scripts on PATH" {
+  run fish_with_home 'string match -q "*/.scripts*" "$PATH"; and echo found'
+  [ "$status" -eq 0 ]
+  [ "$output" = "found" ]
+}
+
+@test "the repository's scripts are callable from fish" {
+  for script in pmux tssh killport urlencode tmux-window-fzf; do
+    run fish_with_home "command -v $script >/dev/null; and echo ok"
+    [ "$output" = "ok" ] || {
+      echo "$script is not on PATH in fish"
+      false
+    }
+  done
+}
+
+# --- UTF-8 locale (#273) -----------------------------------------------------
+
+@test "fish prefers en_US.UTF-8 when it is generated" {
+  stub_locale 'C\nC.utf8\nen_US.utf8\nPOSIX'
+  run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL"
+  [ "$status" -eq 0 ]
+  [ "$output" = "en_US.UTF-8" ]
+}
+
+@test "fish falls back to C.UTF-8 when that is all there is" {
+  stub_locale 'C\nC.utf8\nPOSIX'
+  run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL"
+  [ "$status" -eq 0 ]
+  [ "$output" = "C.UTF-8" ]
+}
+
+@test "fish sets no locale when none is generated" {
+  stub_locale 'C\nPOSIX'
+  # fish sets LANG=C.UTF-8 on its own when the environment has no usable
+  # locale, so LC_ALL is what shows whether the block actually ran.
+  run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "fish and zsh choose the same locale" {
+  command -v zsh >/dev/null || skip "zsh not available"
+  stub_locale 'C\nC.utf8\nen_US.utf8\nPOSIX'
+
+  from_fish="$(env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL")"
+  from_zsh="$(env PATH="$WORK/bin:$PATH" zsh -c "source $REPO/.zshrc >/dev/null 2>&1; echo \$LC_ALL")"
+  [ "$from_fish" = "$from_zsh" ] || {
+    echo "fish=[$from_fish] zsh=[$from_zsh]"
+    false
+  }
+}

--- a/test/fish-config.bats
+++ b/test/fish-config.bats
@@ -90,8 +90,15 @@ stub_locale() {
   command -v zsh >/dev/null || skip "zsh not available"
   stub_locale 'C\nC.utf8\nen_US.utf8\nPOSIX'
 
-  from_fish="$(sh_run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL")"
-  from_zsh="$(sh_run env PATH="$WORK/bin:$PATH" zsh -c "source $REPO/.zshrc >/dev/null 2>&1; echo \$LC_ALL")"
+  # Only the locale block is pulled out of .zshrc, the same way prompt.bats
+  # takes just _prompt_path. Sourcing the whole file would drag in compinit,
+  # plugins and tool hooks -- none of which this is testing, and any one of
+  # which can leave a process behind holding the CI step's pipes open.
+  zsh_locale_block="$(sed -n '/^for _l in /,/^unset _l$/p' "$REPO/.zshrc")"
+  [ -n "$zsh_locale_block" ]
+
+  from_fish="$(sh_run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL" 2>/dev/null)"
+  from_zsh="$(sh_run env PATH="$WORK/bin:$PATH" zsh -c "$zsh_locale_block"'; echo $LC_ALL' 2>/dev/null)"
   [ "$from_fish" = "$from_zsh" ] || {
     echo "fish=[$from_fish] zsh=[$from_zsh]"
     false

--- a/test/fish-config.bats
+++ b/test/fish-config.bats
@@ -19,11 +19,18 @@ teardown() {
   [ -n "${WORK:-}" ] && rm -rf "$WORK"
 }
 
+# Shells are always run with stdin closed and a deadline. A shell that blocks
+# on a read would otherwise stall the CI step for hours instead of failing, and
+# the timeout makes it obvious *which* case is at fault.
+sh_run() {
+  timeout 30 "$@" </dev/null
+}
+
 # Run fish with $HOME pointing at a throwaway directory that has .scripts
 # linked in, the way `make` sets it up.
 fish_with_home() {
   ln -sfn "$(cd "$REPO" && pwd)/.scripts" "$WORK/.scripts"
-  HOME="$WORK" fish -c "source $FISH_DIR/config.fish 2>/dev/null; $1"
+  HOME="$WORK" sh_run fish -c "source $FISH_DIR/config.fish 2>/dev/null; $1"
 }
 
 # Put a stub `locale` earlier on PATH so the available locales can be varied.
@@ -58,14 +65,14 @@ stub_locale() {
 
 @test "fish prefers en_US.UTF-8 when it is generated" {
   stub_locale 'C\nC.utf8\nen_US.utf8\nPOSIX'
-  run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL"
+  run sh_run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL"
   [ "$status" -eq 0 ]
   [ "$output" = "en_US.UTF-8" ]
 }
 
 @test "fish falls back to C.UTF-8 when that is all there is" {
   stub_locale 'C\nC.utf8\nPOSIX'
-  run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL"
+  run sh_run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL"
   [ "$status" -eq 0 ]
   [ "$output" = "C.UTF-8" ]
 }
@@ -74,7 +81,7 @@ stub_locale() {
   stub_locale 'C\nPOSIX'
   # fish sets LANG=C.UTF-8 on its own when the environment has no usable
   # locale, so LC_ALL is what shows whether the block actually ran.
-  run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL"
+  run sh_run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL"
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
 }
@@ -83,8 +90,8 @@ stub_locale() {
   command -v zsh >/dev/null || skip "zsh not available"
   stub_locale 'C\nC.utf8\nen_US.utf8\nPOSIX'
 
-  from_fish="$(env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL")"
-  from_zsh="$(env PATH="$WORK/bin:$PATH" zsh -c "source $REPO/.zshrc >/dev/null 2>&1; echo \$LC_ALL")"
+  from_fish="$(sh_run env PATH="$WORK/bin:$PATH" fish -c "source $FISH_DIR/conf.d/locale.fish; echo \$LC_ALL")"
+  from_zsh="$(sh_run env PATH="$WORK/bin:$PATH" zsh -c "source $REPO/.zshrc >/dev/null 2>&1; echo \$LC_ALL")"
   [ "$from_fish" = "$from_zsh" ] || {
     echo "fish=[$from_fish] zsh=[$from_zsh]"
     false


### PR DESCRIPTION
Closes #271。
Closes #273。

fish と zsh の差分対応を 3 つ。前者 2 つは「壊れていても気付けない」もの、3 つ目はそれを検知する仕組みの穴埋めです。

## #271 — `.scripts` が PATH に無い

zsh は `.zshrc:142` で追加していますが fish は追加しておらず、**`.scripts/` のツールが一切呼べません**でした。`duck` / `google` は `urlencode` を PATH 経由で呼ぶので連鎖して壊れます。

```fish
# Scripts (.zshrc does the same; .scripts is symlinked into $HOME by `make`)
set -gx PATH $HOME/.scripts $PATH
```

修正後、`make` 済みの `$HOME` で `pmux` / `tssh` / `killport` / `urlencode` / `tmux-window-fzf` がすべて解決することを確認。

## #273 — UTF-8 ロケールの強制

#228 で `.zshrc` に入れたものを `conf.d/locale.fish` として移植。Termius のようにロケールを転送しない SSH クライアント向けの対応です。「**実際に生成されているロケールだけを設定する**」という条件も維持しています。

`locale` のスタブを差し込んで検証:

| 環境 | 結果 |
| --- | --- |
| `en_US.utf8` あり | `en_US.UTF-8`（zsh と一致） |
| `C.utf8` のみ | `C.UTF-8` |
| UTF-8 なし | 何も設定しない |

3 番目について補足です。**fish は使えるロケールが無いとき自分で `LANG=C.UTF-8` を設定する**ため、`LANG` を見ても自作スクリプトが動いたかは判別できません。`LC_ALL` が空のままかで確認しています。

## ドリフト検知が関数を見ていなかった

#266 で入れたチェックは **`alias` 行しか比較していませんでした**。fish が関数として実装しているものは対象外で、実際にそこをすり抜けていたものがあります。

```
zsh : alias ws=peco-workspace   →  cd $(ghq list --full-path | peco)
fish: function ws               →  cd (ghq list --full-path | pf)
```

`pf` は `peco --initial-filter=Fuzzy` なので、**zsh は素の peco、fish は Fuzzy フィルタ有効**。`cl` や `up` と同じ「同名で別物」なのに CI は緑のままでした。fish 側を素の `peco` に直しています。

### チェックの拡張

各シェルが公開する**名前空間全体**（エイリアス + 関数）を比較するようにしました。ただし片方がエイリアスでもう片方が関数のペアは、fish と zsh で構文が違う以上テキスト比較ができません。そこで **`KNOWN_EQUIVALENT` に「手で確認した」という記録付きで載せることを必須**にしています。

現在の 6 件は全部中身を突き合わせ済みです。4 件はコマンド置換の構文差だけ、残り 2 件は理由を明記しました。

```
#   ws        zsh calls peco-workspace; fish inlines the same one-liner
#   n         zsh calls list(); fish inlines it plus a trailing-space strip,
#             because fish's (...) does not word-split the way zsh's $(...) does
```

これで**新しい不一致ペアはレビューを通らないと CI が通りません**。逆に、リストが実態より長生きしないよう「もう両方に存在しない名前が載っていたら落とす」チェックも入れています。

## 動作確認

silent failure ばかりなので、それぞれ壊して落ちることを確認しました。

| 壊し方 | 結果 |
| --- | --- |
| `.scripts` の行を削除 | 2 件失敗 |
| `locale.fish` を削除 | 4 件失敗 |
| fish に zsh の alias と同名の関数を新設 | `not ok 5` — 該当名を列挙して失敗 |
| `KNOWN_EQUIVALENT` を陳腐化させる | `not ok 6` — 古い名前を指摘して失敗 |

- `test/fish-config.bats` → 6/6 pass（新規）
- `test/aliases.bats` → 6/6 pass（3 → 6 に拡張）
- aliases / fish-config / prompt / makefile 合わせて 38 pass、失敗 0
- `fish -n` / `zsh -n` / `zsh -c "source ./.zshrc"` → OK
- `actionlint` → clean