### PR TITLE
feat: unify Ctrl+R on history search and port the keybindings to fish

### DIFF
--- a/.config/fish/conf.d/aliases.fish
+++ b/.config/fish/conf.d/aliases.fish
@@ -109,8 +109,21 @@ function ws
   cd (ghq list --full-path | peco)
 end
 
+# NOTE: these mirror the bindkey lines in .zsh/, which are the source of truth.
+# Several of them take over a fish default (Ctrl+A beginning-of-line, Ctrl+F
+# accept-autosuggestion, Ctrl+W backward-kill-word, Ctrl+N history-next); that
+# is deliberate, since the point is for the two shells to feel the same.
 function fish_user_key_bindings
+  # history search -- Ctrl+Z as well, which is where zsh had it first
   bind \cr 'peco_select_history (commandline -b)'
+  bind \cz 'peco_select_history (commandline -b)'
+
+  bind \cw ws              # ghq repo via peco
+  bind \ca wf              # ghq repo via fzf, with README preview
+  bind \cf pmux            # ghq repo -> tmux session
+  bind \cb switch-worktree # git worktree
+  bind \cn run-script      # package.json script
+
   bind \c] ws
 end
 
@@ -128,6 +141,9 @@ end
 
 # alias to copy file or folder to dotfiles repository
 # alias cpdf="cp -r "(ls -a | pf)" $DOTFILES"
+
+# alias for run-script (bound to Ctrl+N, see fish_user_key_bindings)
+alias rs="run-script"
 
 # alias for npm scripts
 # list npm scripts and output chosen script

--- a/.config/fish/functions/run-script.fish
+++ b/.config/fish/functions/run-script.fish
@@ -1,0 +1,33 @@
+# NOTE: mirrors run-script in .zsh/81-run-script.zsh, which is the source of
+# truth. Same selector, same package-manager detection, same lockfile order.
+function run-script --description 'pick a package.json script with fzf and run it'
+    if not test -f package.json
+        echo "No package.json found in current directory"
+        return 1
+    end
+
+    # ::: as the delimiter, so script names containing a colon still split
+    set -l entries (jq -r '.scripts | to_entries | .[] | .key + ":::" + .value' package.json)
+    if test (count $entries) -eq 0
+        echo "No scripts found in package.json"
+        return 1
+    end
+
+    set -l selected (printf '%s\n' $entries | fzf --layout=reverse --prompt="Run script: " \
+        --preview 'echo -e "Command:\n\n$(echo {} | cut -d: -f3-)"')
+    test -n "$selected"; or return 0
+
+    set -l script_name (string replace -r ':::.*' '' -- $selected)
+
+    set -l cmd npm run
+    if test -f yarn.lock
+        set cmd yarn
+    else if test -f pnpm-lock.yaml
+        set cmd pnpm
+    else if test -f bun.lockb
+        set cmd bun run
+    end
+
+    echo "Running: $cmd $script_name"
+    command $cmd $script_name
+end

--- a/.config/fish/functions/switch-worktree.fish
+++ b/.config/fish/functions/switch-worktree.fish
@@ -1,0 +1,31 @@
+# .scripts/switch-worktree is bash and has to be sourced to cd, which fish
+# cannot do, so this is the fish equivalent. Keep it in step with that script.
+function switch-worktree --description 'cd to a git worktree picked with fzf'
+    set -l lines (git worktree list 2>/dev/null | tail -n +2)
+    if test (count $lines) -eq 0
+        echo "No linked worktrees for this repository"
+        return 1
+    end
+
+    set -l paths
+    set -l labels
+    for line in $lines
+        set -l fields (string split -n ' ' -- $line)
+        set -l path $fields[1]
+        set -l branch (string trim -c '[]' -- $fields[3])
+        set -l name (path basename $path)
+        # The script shows "Nothing" when the branch matches the directory name,
+        # i.e. when the branch adds no information beyond the worktree itself.
+        test "$branch" = "$name"; and set branch Nothing
+
+        set -a paths $path
+        set -a labels (printf '%-30s %s' (path basename (path dirname $path))/$name $branch)
+    end
+
+    set -l picked (printf '%s\n' $labels | cat -n | fzf --layout=reverse --prompt="Select worktree: " \
+        --preview 'echo -e "Currently working on: \n\n$(echo {} | cut -f2-)"')
+    test -n "$picked"; or return 0
+
+    set -l index (string trim -- (string split -m1 \t -- $picked)[1])
+    cd $paths[$index]
+end

--- a/.config/fish/functions/wf.fish
+++ b/.config/fish/functions/wf.fish
@@ -1,0 +1,9 @@
+# NOTE: mirrors fzf-workspace in .zsh/73-workspace.zsh, which is the source of
+# truth. The preview runs in fzf's own shell (sh), so that part is shared
+# verbatim between the two.
+function wf --description 'cd to a ghq repo picked with fzf, previewing its README'
+    set -l preview 'REPO={}; README=$(find "$REPO" -maxdepth 1 -name "README*" -type f | head -n 1); if [ -z "$README" ]; then README=$(find "$REPO/main" "$REPO/master" "$REPO/develop" "$REPO/dev" -maxdepth 1 -name "README*" -type f 2>/dev/null | head -n 1); fi; if [ -n "$README" ]; then bat --color=always --style=header,grid --line-range :80 "$README"; else echo "No README found"; fi'
+
+    set -l repo (ghq list --full-path | fzf --layout=reverse --preview $preview)
+    test -n "$repo"; and cd $repo
+end

--- a/.zsh/70-aliases.zsh
+++ b/.zsh/70-aliases.zsh
@@ -17,7 +17,8 @@ zle-refresh() {
 zle -N zle-refresh
 # alias
 alias zshedit="vim ~/.zshrc"
-bindkey '^R' zle-refresh
+# Ctrl+R is history search, matching fish and every other shell; reload the
+# config with the `zshr` alias instead.
 alias zshr=refresh
 
 # lynx

--- a/.zsh/74-peco-fzf.zsh
+++ b/.zsh/74-peco-fzf.zsh
@@ -19,6 +19,7 @@ peco-history-selection() {
 }
 
 zle -N peco-history-selection
+bindkey '^R' peco-history-selection
 bindkey '^Z' peco-history-selection
 
 autoload -Uz compinit && compinit

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ If you touch aliases:
 
 `test/aliases.bats` enforces that in CI. It compares aliases textually, and — because a name can be an alias in one shell and a function in the other, where there is nothing to compare across two different syntaxes — it also requires any such pair to be listed in `KNOWN_EQUIVALENT` with a note saying it was checked by hand. A new mismatched pair therefore cannot appear unnoticed. It also fails if an alias is defined twice across the modules (where the later definition silently wins).
 
+Keybindings are mirrored too: `Ctrl+R`/`Ctrl+Z` history search, `Ctrl+W`/`Ctrl+A` ghq repo pickers, `Ctrl+F` tmux session, `Ctrl+B` git worktree, `Ctrl+N` package.json script. Several of them take over a fish default (`Ctrl+A` beginning-of-line, `Ctrl+F` accept-autosuggestion, `Ctrl+W` backward-kill-word), which is deliberate — the point is for the two shells to feel the same.
+
 The prompt is the one place where fish deliberately carries a copy of zsh logic: `.config/fish/functions/__prompt_path.fish` mirrors `_prompt_path` in `.zsh/40-prompt.zsh`, and `__prompt_git_state.fish` mirrors the `vcs_info` zstyles. `test/prompt.bats` runs both implementations over the same repository layouts and fails if they disagree.
 
 ### Setting up fish

--- a/test/aliases.bats
+++ b/test/aliases.bats
@@ -27,7 +27,10 @@ FISH_ALIASES="$FISH_DIR/conf.d/aliases.fish"
 #   ws        zsh calls peco-workspace; fish inlines the same one-liner
 #   n         zsh calls list(); fish inlines it plus a trailing-space strip,
 #             because fish's (...) does not word-split the way zsh's $(...) does
-KNOWN_EQUIVALENT="gbd gcod gpcb n rundroid ws"
+#   wf        zsh aliases fzf-workspace; fish inlines it, sharing the fzf
+#             preview string verbatim since fzf runs it with sh either way
+#   run-script  same selector, same lockfile order; rewritten in fish syntax
+KNOWN_EQUIVALENT="gbd gcod gpcb n run-script rundroid wf ws"
 
 # Print "name<TAB>definition" for every `alias name=...` line in $1. The
 # surrounding quotes and any trailing comment are stripped so that the two

--- a/test/fish-config.bats
+++ b/test/fish-config.bats
@@ -9,6 +9,7 @@
 
 REPO="$BATS_TEST_DIRNAME/.."
 FISH_DIR="$BATS_TEST_DIRNAME/../.config/fish"
+FISH_FUNCS="$FISH_DIR/functions"
 
 setup() {
   command -v fish >/dev/null || skip "fish not available"
@@ -103,4 +104,66 @@ stub_locale() {
     echo "fish=[$from_fish] zsh=[$from_zsh]"
     false
   }
+}
+
+# --- keybinding targets ported from zsh (#272) --------------------------------
+
+# fzf is interactive, so it is replaced with "take the first candidate". That is
+# enough to exercise everything around the picker.
+make_repo() {
+  git init -q "$1"
+  git -C "$1" config user.email t@example.com
+  git -C "$1" config user.name test
+  git -C "$1" commit -qm init --allow-empty
+}
+
+fish_pick_first() {
+  sh_run fish -c "
+    source $FISH_FUNCS/$1.fish
+    function fzf; head -1; end
+    $2
+  "
+}
+
+@test "run-script refuses to run outside a package.json directory" {
+  run sh_run fish -c "cd $WORK; source $FISH_FUNCS/run-script.fish; run-script"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No package.json"* ]]
+}
+
+@test "run-script picks the package manager from the lockfile" {
+  mkdir -p "$WORK/pkg"
+  cat >"$WORK/pkg/package.json" <<'JSON'
+{ "scripts": { "start": "true" } }
+JSON
+
+  run fish_pick_first run-script "cd $WORK/pkg; run-script"
+  [[ "$output" == *"Running: npm run start"* ]]
+
+  for pair in "yarn.lock:yarn start" "pnpm-lock.yaml:pnpm start" "bun.lockb:bun run start"; do
+    lock="${pair%%:*}"
+    expected="${pair#*:}"
+    : >"$WORK/pkg/$lock"
+    run fish_pick_first run-script "cd $WORK/pkg; run-script"
+    [[ "$output" == *"Running: $expected"* ]] || {
+      echo "$lock should select '$expected', got: $output"
+      false
+    }
+    rm -f "$WORK/pkg/$lock"
+  done
+}
+
+@test "switch-worktree reports when there are no linked worktrees" {
+  make_repo "$WORK/repo"
+  run sh_run fish -c "cd $WORK/repo; source $FISH_FUNCS/switch-worktree.fish; switch-worktree"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No linked worktrees"* ]]
+}
+
+@test "switch-worktree changes to the selected worktree" {
+  make_repo "$WORK/repo"
+  git -C "$WORK/repo" worktree add -q "$WORK/wt" -b feature
+  run fish_pick_first switch-worktree "cd $WORK/repo; switch-worktree; echo \$PWD"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$WORK/wt"* ]]
 }


### PR DESCRIPTION
Closes #272。

## `Ctrl+R` を履歴検索に統一

zsh では設定リロード、fish では履歴検索と**同じキーが別物**でした。fish・readline・その他のシェルすべてに合わせて**履歴検索**に寄せます。

| | 変更前 | 変更後 |
| --- | --- | --- |
| zsh `Ctrl+R` | `zle-refresh`（設定リロード） | `peco-history-selection` |
| zsh `Ctrl+Z` | `peco-history-selection` | 据え置き（今の指の記憶はそのまま使えます） |
| fish `Ctrl+R` | `peco_select_history` | 据え置き |
| fish `Ctrl+Z` | — | `peco_select_history` |

設定リロードのキーバインドは外しました。既存の **`zshr` エイリアス**が同じことをするので機能自体は残ります。

> **`Ctrl+I` について**
> リロードの移動先として指定いただきましたが、**`Ctrl+I` は Tab と同じバイト（0x09）**です。端末が両者を区別できないため、割り当てると両シェルで Tab 補完が壊れます。
> ```
> Tab = 0x09 / Ctrl+I = 0x09
> zsh :  "^I" → expand-or-complete
> fish:  \t   → complete
> ```
> このため今回は割り当てていません。別のキー（`Ctrl+X Ctrl+R` など空いている組み合わせ）を決めていただければ追加します。

## キーバインドを fish に移植

| キー | 動作 |
| --- | --- |
| `Ctrl+W` | ghq リポジトリ（peco） |
| `Ctrl+A` | ghq リポジトリ（fzf、README プレビュー付き） |
| `Ctrl+F` | pmux（tmux セッション） |
| `Ctrl+B` | git worktree |
| `Ctrl+N` | package.json のスクリプト |
| `Ctrl+Z` | 履歴検索 |

いくつかは **fish の既定バインドを潰します**（`Ctrl+A` 行頭移動、`Ctrl+F` 補完候補の確定、`Ctrl+W` 単語削除、`Ctrl+N` 履歴送り）。両シェルの操作感を揃えるのが目的なので意図的ですが、`Ctrl+F` は fish の autosuggestion 確定に使っている場合は影響が大きいので、必要なら戻します。

## 移植に伴って追加した fish 関数

3 つは fish 側に実装が存在しなかったので新規に書きました。

- **`wf.fish`** — fzf 版のリポジトリ選択。fzf のプレビュー文字列は fzf が `sh` で実行するので、zsh 側とそのまま共有しています
- **`run-script.fish`** — 同じセレクタ、同じロックファイル優先順位
- **`switch-worktree.fish`** — `.scripts/switch-worktree` は bash かつ `cd` のため source 前提で、fish からは使えないので書き直し

あわせて `alias rs="run-script"` も追加（zsh と同一）。

## 動作確認

実際に動かして確認しました。

**`run-script` のパッケージマネージャ検出**（zsh 版と一致）:
```
none            -> Running: npm run start
yarn.lock       -> Running: yarn start
pnpm-lock.yaml  -> Running: pnpm start
bun.lockb       -> Running: bun run start
```

**`switch-worktree`**: worktree 無しでエラー、選択すると該当ディレクトリに `cd` することを確認。

**キーバインド登録**: 両シェルで `bindkey` / `bind` の出力を確認済み。fish の `Ctrl+Z` は terminfo の `suspend` として登録されます（端末が先に SIGTSTP を処理する環境では発火しない可能性があります）。

## ドリフト検知

`wf` と `run-script` は zsh がエイリアス／関数、fish が関数なのでテキスト比較ができません。**#275 で入れたチェックがこの 2 つを正しく検出しました**:

```
not ok 5 a name defined in both shells is comparable or known-equivalent
#   run-script
#   wf
```

手で突き合わせたうえで `KNOWN_EQUIVALENT` に理由付きで追加しています。

## テスト

`test/fish-config.bats` に 4 ケース追加（計 10）。ロックファイル検出を壊すと落ちることも確認済みです。

- bats 42 pass、失敗 0
- `fish -n` / `zsh -n`（モジュール個別）/ `source .zshrc` すべて OK

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_