### PR TITLE
feat: use vi bindings and vim as the editor in both shells

### DIFF
--- a/.config/fish/conf.d/aliases.fish
+++ b/.config/fish/conf.d/aliases.fish
@@ -114,17 +114,24 @@ end
 # accept-autosuggestion, Ctrl+W backward-kill-word, Ctrl+N history-next); that
 # is deliberate, since the point is for the two shells to feel the same.
 function fish_user_key_bindings
-  # history search -- Ctrl+Z as well, which is where zsh had it first
-  bind \cr 'peco_select_history (commandline -b)'
-  bind \cz 'peco_select_history (commandline -b)'
+  # zsh runs `set -o vi`; match it. fish_variables pins the same choice, so
+  # this does not rewrite that file on every start.
+  fish_vi_key_bindings
 
-  bind \cw ws              # ghq repo via peco
-  bind \ca wf              # ghq repo via fzf, with README preview
-  bind \cf pmux            # ghq repo -> tmux session
-  bind \cb switch-worktree # git worktree
-  bind \cn run-script      # package.json script
+  # Bound in both vi modes, so they work whether or not you are in insert mode.
+  for mode in default insert
+    # history search -- Ctrl+Z as well, which is where zsh had it first
+    bind -M $mode \cr 'peco_select_history (commandline -b)'
+    bind -M $mode \cz 'peco_select_history (commandline -b)'
 
-  bind \c] ws
+    bind -M $mode \cw ws              # ghq repo via peco
+    bind -M $mode \ca wf              # ghq repo via fzf, with README preview
+    bind -M $mode \cf pmux            # ghq repo -> tmux session
+    bind -M $mode \cb switch-worktree # git worktree
+    bind -M $mode \cn run-script      # package.json script
+
+    bind -M $mode \c] ws
+  end
 end
 
 #open code and github

--- a/.config/fish/conf.d/editor.fish
+++ b/.config/fish/conf.d/editor.fish
@@ -1,1 +1,4 @@
-set -x EDITOR vim
+# Mirrors .zsh/50-path.zsh. GIT_EDITOR is what gh and git use; EDITOR is the
+# fallback everything else (crontab, visudo, ...) reads.
+set -gx EDITOR vim
+set -gx GIT_EDITOR vim

--- a/.config/fish/fish_variables
+++ b/.config/fish/fish_variables
@@ -25,7 +25,7 @@ SETUVAR fish_color_status:red
 SETUVAR fish_color_user:brgreen
 SETUVAR fish_color_valid_path:\x2d\x2dunderline
 SETUVAR fish_greeting:\x1d
-SETUVAR fish_key_bindings:fish_default_key_bindings
+SETUVAR fish_key_bindings:fish_vi_key_bindings
 SETUVAR fish_pager_color_completion:\x1d
 SETUVAR fish_pager_color_description:B3A06D\x1eyellow
 SETUVAR fish_pager_color_prefix:white\x1e\x2d\x2dbold\x1e\x2d\x2dunderline

--- a/.zsh/50-path.zsh
+++ b/.zsh/50-path.zsh
@@ -22,6 +22,8 @@ fi
 # Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
 export PATH="$PATH:$HOME/.rvm/bin"
 
-# Set default editor for gh cli to vim
+# Default editor. GIT_EDITOR is what gh and git use; EDITOR is the fallback
+# everything else (crontab, visudo, ...) reads.
+export EDITOR=vim
 export GIT_EDITOR=vim
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ If you touch aliases:
 
 `test/aliases.bats` enforces that in CI. It compares aliases textually, and — because a name can be an alias in one shell and a function in the other, where there is nothing to compare across two different syntaxes — it also requires any such pair to be listed in `KNOWN_EQUIVALENT` with a note saying it was checked by hand. A new mismatched pair therefore cannot appear unnoticed. It also fails if an alias is defined twice across the modules (where the later definition silently wins).
 
+Both shells use vi key bindings (`set -o vi` in zsh, `fish_key_bindings` in fish) and export `EDITOR=vim` and `GIT_EDITOR=vim`.
+
 Keybindings are mirrored too: `Ctrl+R`/`Ctrl+Z` history search, `Ctrl+W`/`Ctrl+A` ghq repo pickers, `Ctrl+F` tmux session, `Ctrl+B` git worktree, `Ctrl+N` package.json script. Several of them take over a fish default (`Ctrl+A` beginning-of-line, `Ctrl+F` accept-autosuggestion, `Ctrl+W` backward-kill-word), which is deliberate — the point is for the two shells to feel the same.
 
 The prompt is the one place where fish deliberately carries a copy of zsh logic: `.config/fish/functions/__prompt_path.fish` mirrors `_prompt_path` in `.zsh/40-prompt.zsh`, and `__prompt_git_state.fish` mirrors the `vcs_info` zstyles. `test/prompt.bats` runs both implementations over the same repository layouts and fails if they disagree.

--- a/test/fish-config.bats
+++ b/test/fish-config.bats
@@ -167,3 +167,20 @@ JSON
   [ "$status" -eq 0 ]
   [[ "$output" == *"$WORK/wt"* ]]
 }
+
+# --- parity with zsh on editor and key bindings (#274) ------------------------
+
+@test "fish and zsh export the same editor variables" {
+  from_fish="$(sh_run fish -c "source $FISH_DIR/conf.d/editor.fish; echo \$EDITOR \$GIT_EDITOR" 2>/dev/null)"
+  from_zsh="$(sh_run zsh -c "source $REPO/.zsh/50-path.zsh >/dev/null 2>&1; echo \$EDITOR \$GIT_EDITOR" 2>/dev/null)"
+  [ "$from_fish" = "vim vim" ]
+  [ "$from_fish" = "$from_zsh" ]
+}
+
+@test "both shells use vi key bindings" {
+  # zsh sets it with `set -o vi`; fish pins fish_key_bindings as a universal
+  # variable, which is committed so it does not get rewritten on every start.
+  run sh_run zsh -c "source $REPO/.zsh/00-core.zsh >/dev/null 2>&1; setopt"
+  [[ "$output" == *"vi"* ]]
+  grep -qx "SETUVAR fish_key_bindings:fish_vi_key_bindings" "$FISH_DIR/fish_variables"
+}


### PR DESCRIPTION
Closes #274。

## vi バインドに統一

zsh は `set -o vi`、fish は emacs バインドでした。fish も vi に揃えます。

### `fish_variables` の扱い

`fish_key_bindings` は**universal variable** で、`fish_variables` はこのリポジトリにコミットされています。つまり実行時にバインドを切り替えると、**そのファイルが書き換わってリポジトリが毎回汚れます**。実際に確認しました。

```
（コミット済みの値が fish_default_key_bindings のまま切り替えた場合）
fish_variables 変化: あり ⚠️
```

なので**コミット済みの値のほうを `fish_vi_key_bindings` に変更**しました。値が一致していれば fish は書き込まないので churn は出ません。

```
（値を揃えた状態）
fish_variables 変化: なし ✅
```

### カスタムバインドは両モードに登録

vi モードでは `default`（コマンドモード）と `insert` が分かれるので、#272 で入れた `Ctrl+W` などは**両方に登録**しています。insert モードから抜けているかどうかを気にせず使えます。

```
bind \cw ws
bind -M insert \cw ws
（Ctrl+R / Ctrl+A / Ctrl+F / Ctrl+B / Ctrl+N / Ctrl+Z / Ctrl+] も同様）
```

## `EDITOR` / `GIT_EDITOR`

きれいに食い違っていたので両方揃えました。

| | 変更前 zsh | 変更前 fish | 変更後（両方） |
| --- | --- | --- | --- |
| `EDITOR` | 未設定 | `vim` | `vim` |
| `GIT_EDITOR` | `vim` | 未設定 | `vim` |

zsh では `EDITOR` が未設定だったため、`git` は vim を開くのに **`crontab` や `visudo` はシステム既定のエディタ**が開いていました。

## 動作確認

```
zsh : EDITOR=vim GIT_EDITOR=vim   /  bindkey -A viins main
fish: EDITOR=vim GIT_EDITOR=vim   /  fish_key_bindings=fish_vi_key_bindings
```

カスタムバインドが `default` / `insert` の両モードに入っていることも確認済みです。

## テスト

`test/fish-config.bats` に 2 ケース追加（計 12）。

- **エディタ変数が両シェルで一致するか** — 片方を `nano` に変えると落ちることを確認
- **両シェルが vi バインドか** — zsh は `setopt`、fish はコミット済み uvar を検証

全体で bats 44 pass、失敗 0。`fish -n` / `zsh -n`（モジュール個別）/ `source .zshrc` すべて OK。

## 残しているもの

issue の 3 番目、履歴設定（zsh は `SHARE_HISTORY` などを明示、fish は既定で同等）は**対応不要**と判断してそのままにしています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_