### PR TITLE
fix(windows): make bootstrap.ps1 non-destructive and work on a fresh machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,19 @@ make config     # symlink .config entries
 
 ## Windows
 
-Run `bootstrap.ps1` to setup configuration for PowerShell
+Run `bootstrap.ps1` to point the PowerShell profile at this repository:
 
 ```
 ./bootstrap.ps1
 ```
+
+It writes a `$PROFILE` that sources `windows/*.ps1` from the clone, in filename
+order — the same idea as the symlinks `make` creates on Unix. A `git pull` takes
+effect on the next shell, so this only needs running once per machine. Edit
+`windows/*.ps1` here rather than `$PROFILE`, which is overwritten.
+
+Any profile you already had is copied to `$PROFILE.bak` first. Re-running is
+safe: it will not overwrite that backup with the generated loader.
 
 ## Shells
 

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -1,16 +1,43 @@
-# Check each .ps1 files in windows directory and set up so that it runs when shell starts up
+# Point $PROFILE at this repository.
+#
+# The profile becomes a small loader that dot-sources windows/*.ps1 from here,
+# rather than a copy of them. That mirrors how `make` symlinks the Unix
+# dotfiles: a `git pull` takes effect on the next shell, with no need to re-run
+# this script. Edit windows/*.ps1 in the repository, not $PROFILE.
 
-# Get the current directory
-$dir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ErrorActionPreference = 'Stop'
 
-# Remove the existing profile
-Remove-Item -Path $PROFILE -Force
+$marker = '# managed by Naturalclar/dotfiles bootstrap.ps1 -- edits here are overwritten'
+$partsGlob = Join-Path (Join-Path $PSScriptRoot 'windows') '*.ps1'
 
-# Get all .ps1 files in windows directory
-$files = Get-ChildItem -Path $dir\windows\*.ps1
-
-# For each file, add the contents to the profile
-foreach ($file in $files) {
-    $content = Get-Content $file
-    Add-Content -Path $PROFILE -Value $content
+# $PROFILE points into Documents\PowerShell, which does not exist until the
+# first profile is created. Add-Content will not create it for us.
+$profileDir = Split-Path -Parent $PROFILE
+if (-not (Test-Path -LiteralPath $profileDir)) {
+    New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
 }
+
+# Never throw away a profile we did not write. Re-running this script is a
+# no-op for the backup, since by then the marker is already in place.
+if (Test-Path -LiteralPath $PROFILE) {
+    $existing = Get-Content -LiteralPath $PROFILE -Raw
+    if ($null -eq $existing -or -not $existing.Contains($marker)) {
+        $backup = "$PROFILE.bak"
+        Copy-Item -LiteralPath $PROFILE -Destination $backup -Force
+        Write-Host "Backed up the existing profile to $backup"
+    }
+}
+
+# Single-quoted in the generated file so nothing in the path is expanded at
+# load time; '' is the escape for a literal quote.
+$escapedGlob = $partsGlob.Replace("'", "''")
+
+Set-Content -LiteralPath $PROFILE -Value @(
+    $marker
+    "# Sourced from $PSScriptRoot -- edit windows/*.ps1 there."
+    ''
+    "Get-ChildItem -Path '$escapedGlob' | Sort-Object Name | ForEach-Object { . `$_.FullName }"
+)
+
+Write-Host "Wrote $PROFILE"
+Write-Host "It now sources $partsGlob on every start."


### PR DESCRIPTION
Closes #279。

issue はコード読解ベースで書きましたが、**PowerShell 7.4.6 を入れて旧版を実際に動かし、3 つとも再現を取りました**。

## 1. 新規マシンで失敗する（再現済み）

`$PROFILE` は `Documents\PowerShell` 配下にあり、これは初めてプロファイルが作られるまで存在しません。`Add-Content` は親ディレクトリを作らないので、旧版はこうなります。

```
Add-Content: Could not find a part of the path '.../powershell/Microsoft.PowerShell_profile.ps1'
PROFILE 存在: False
```

**プロファイルが 1 つも作られないまま終わります。** #259（`make config` が `~/.config` 無しで全滅していた）と同じ形です。

## 2. 既存プロファイルを無条件で削除する

```powershell
Remove-Item -Path $PROFILE -Force
```

自分で書いた設定があっても、確認もバックアップもなく消えていました。

## 3. コピーなので、リポジトリを更新しても反映されない（再現済み）

旧版は `windows/*.ps1` を連結してコピーしていました。`windows/` にファイルを足して新しいシェルを開いても、反映されません。

```
新版 LOADED = a,b,c   ← リポジトリに 30-c.ps1 を足しただけで反映
旧版 LOADED = a,b     ← bootstrap.ps1 を再実行するまで反映されない
```

しかも再実行すると 2 の削除がまた走ります。

## 変更内容

`$PROFILE` を**ローダー**にしました。Unix 側で `make` が symlink を張るのと同じ考え方です。

```powershell
# managed by Naturalclar/dotfiles bootstrap.ps1 -- edits here are overwritten
# Sourced from C:\path\to\dotfiles -- edit windows/*.ps1 there.

Get-ChildItem -Path 'C:\path\to\dotfiles\windows\*.ps1' | Sort-Object Name | ForEach-Object { . $_.FullName }
```

- **親ディレクトリを作ってから書く**ので新規マシンで通ります
- **既存プロファイルは `$PROFILE.bak` に退避**します
- **再実行しても `.bak` を潰しません**。生成したファイルにマーカー行があるので、2 回目以降はバックアップを取りません
- **`git pull` だけで反映されます**。再実行は不要です
- `Sort-Object Name` で読み込み順を明示しました（`terminal.ps1` の `prompt` が `alias.ps1` の `get_current_branch` に依存しているため、順序は意味を持ちます）

## 動作確認

pwsh 7.4.6 で 4 ケース確認しました。

| ケース | 結果 |
| --- | --- |
| プロファイルも親ディレクトリも無い（新規マシン） | 親ごと作成して書き込み成功 |
| 既存プロファイルあり | `.bak` に退避され、中身も保持 |
| 再実行 | `.bak` は元のまま、プロファイルは再生成 |
| `windows/` にファイル追加 | **再実行なしで反映** |

あわせてリポジトリ内の `.ps1` 12 本すべてがパースできることも確認しました（CI 化は #283）。

## 補足

Windows 実機では未検証です。検証は Linux 上の pwsh 7.4.6 で行っており、パス区切りやプロファイルの場所は異なります。ただし今回触れたのは `Join-Path` / `Split-Path` / `New-Item` / `Copy-Item` / `Set-Content` といったクロスプラットフォームな API だけなので、挙動は同じはずです。**マージ前に実機で一度流していただけると確実です。**

README の Windows セクションも実態に合わせて更新しました。

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_