### PR TITLE
ci: parse and lint the PowerShell scripts, and document Windows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,6 +50,48 @@ jobs:
           bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
 
+  # The Windows scripts were the only ones nothing checked. pwsh is preinstalled
+  # on ubuntu-latest and parsing does not need Windows, so no Windows runner.
+  powershell:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Check PowerShell syntax
+        shell: pwsh
+        run: |
+          $failed = 0
+          Get-ChildItem -Path . -Filter *.ps1 -Recurse | ForEach-Object {
+            $path = Resolve-Path -Relative $_.FullName
+            $errors = $null
+            [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$null, [ref]$errors) | Out-Null
+            if ($errors) {
+              $failed++
+              foreach ($e in $errors) {
+                Write-Host "::error file=$path,line=$($e.Extent.StartLineNumber)::$($e.Message)"
+              }
+            } else {
+              Write-Host "ok $path"
+            }
+          }
+          exit $failed
+      # Warnings are printed but do not fail the build; only Error-severity
+      # findings do. Tighten this once the warning list has been triaged.
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser -ErrorAction Stop
+          $results = @(Invoke-ScriptAnalyzer -Path . -Recurse)
+          if ($results.Count -eq 0) {
+            Write-Host "PSScriptAnalyzer: no findings"
+          } else {
+            $results | Format-Table -AutoSize RuleName, Severity, ScriptName, Line, Message
+          }
+          $errors = @($results | Where-Object { $_.Severity -eq 'Error' })
+          Write-Host "$($errors.Count) error-severity finding(s)"
+          if ($errors.Count -gt 0) { exit 1 }
+
   bats:
     runs-on: ubuntu-latest
     # These tests spawn shells; a shell that blocks on a read would otherwise

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `make vscodeExtensions` — sync VSCode extensions via `configs/.vscode/vscodeSync.sh`
 - `make list` — show which dotfiles will be symlinked
 - `make help` — print all make targets
-- Windows setup: run `./bootstrap.ps1` to concatenate `windows/*.ps1` into the PowerShell `$PROFILE`
+- Windows setup: run `./bootstrap.ps1` to point the PowerShell `$PROFILE` at `windows/*.ps1` in the clone; the `setup-*.ps1` scripts symlink the remaining configs and need Developer Mode or an elevated shell
 
 ## CI
 
 - **lint.yml** — checks `.zshrc` and each `.zsh/*.zsh` module with `zsh -n`, sources the whole config, then runs shellcheck, actionlint, gitleaks and the bats suites on Ubuntu
 - **make.yml** — runs `make` on macOS
+- PowerShell scripts are parsed and linted with PSScriptAnalyzer on Ubuntu (`pwsh` needs no Windows runner for that); nothing exercises them on Windows
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,42 @@ effect on the next shell, so this only needs running once per machine. Edit
 Any profile you already had is copied to `$PROFILE.bak` first. Re-running is
 safe: it will not overwrite that backup with the generated loader.
 
+### Everything else on Windows
+
+`bootstrap.ps1` only sets up the shell. The rest is separate scripts, each
+creating one symlink:
+
+| Script | Links |
+| --- | --- |
+| `setup-nvim.ps1` | `.config/nvim` → `%USERPROFILE%\AppData\Local\nvim` |
+| `setup-wezterm.ps1` | `.wezterm.lua` → `%USERPROFILE%` |
+| `setup-komorebi.ps1` | `.config/komorebi/*.json` → `%USERPROFILE%\.config` |
+| `setup-whkdrc.ps1` | `.config/whkdrc` → `%USERPROFILE%\.config` |
+| `setup-yasb.ps1` | `.yasb` → `%USERPROFILE%` |
+
+**Creating symlinks on Windows needs either an elevated shell or Developer Mode**
+(Settings → Privacy & security → For developers). Without one of those,
+`New-Item -ItemType SymbolicLink` fails with a permissions error.
+
+These are not idempotent yet and assume `%USERPROFILE%\.config` already exists —
+see #280.
+
+The window-manager side is [komorebi](https://github.com/LGUG2Z/komorebi) with
+[whkd](https://github.com/LGUG2Z/whkd) for hotkeys and
+[yasb](https://github.com/amnweb/yasb) for the status bar;
+`powershell/komorebi-start.ps1` and `komorebi-stop.ps1` (plus `.bat` wrappers)
+drive it. `ahk/` holds AutoHotKey scripts for remapping Windows to Ctrl,
+switching input language, and a few shortcuts — there is no setup script for
+those, so place them in the startup folder yourself.
+
+There is no `Brewfile` equivalent: the tools above, plus whatever
+`windows/path.ps1` expects (scoop, direnv, poetry), have to be installed by
+hand.
+
+CI runs on Linux and macOS only. The PowerShell scripts are parsed and linted
+with PSScriptAnalyzer on every push, but nothing exercises them on Windows —
+changes there are worth trying on a real machine.
+
 ## Shells
 
 **zsh is the source of truth.** It is the shell this repo is built around: it is what `install.sh` sets up, what CI lints (`zsh -n` per module plus a full `source`), and where every alias, function and keybinding lands first.


### PR DESCRIPTION
Closes #283。

Windows 関連のファイルだけが**何の検査も受けていませんでした**。zsh は `zsh -n`（#276 でモジュール個別）、シェルスクリプトは shellcheck、ワークフローは actionlint、fish は `fish -n` があるのに、`.ps1` は構文エラーがあってもマージできる状態でした。#279 / #280 / #281 がすべて「読んだだけ」で見つかったのは、この穴があったからです。

## CI

`powershell` ジョブを追加しました。**`ubuntu-latest` で完結します**（`pwsh` はプリインストール済みで、パースと lint に Windows は不要）。

### 1. 構文チェック

PowerShell 本体のパーサで全 `.ps1` を検査します。外部依存なしです。

```powershell
[System.Management.Automation.Language.Parser]::ParseFile($file, [ref]$null, [ref]$errors)
```

エラー時は `::error file=...,line=...` で出すので、**PR の該当行にインラインで表示されます**。

### 2. PSScriptAnalyzer

`Invoke-ScriptAnalyzer -Path . -Recurse` を実行します。**失敗扱いにするのは Error severity のみ**で、Warning は出力するだけにしています。理由は下の「未検証の点」を参照してください。

## 動作確認

pwsh 7.4.6 をこのリポジトリに入れて、構文チェックを実際に流しました。

```
ok ./bootstrap.ps1
ok ./setup-komorebi.ps1
... (全 12 本)
正常時 → 終了コード=0
```

わざと構文エラーを入れると、ちゃんと検出して落ちます。

```
::error file=./windows/path.ps1,line=16::Missing closing '}' in statement block or type definition.
構文エラーあり → 終了コード=1
```

## 未検証の点

**PSScriptAnalyzer はローカルで実行できていません。** このコンテナから PowerShell Gallery に到達できないためです。

```
$ curl -o /dev/null -w "%{http_code}" https://www.powershellgallery.com/api/v2
000
```

つまり**どんな指摘が何件出るか分からない**状態です。いきなり Warning でも落とす設定にすると初回から赤くなる可能性が高いので、まず Error のみを失敗条件にして、Warning は一覧を出すだけにしました。初回の CI で内容を見てから、必要なら締めるのが良いと思います。

## README

Windows セクションが 3 行しかなく、`bootstrap.ps1` しか案内していませんでした。以下を追記しています。

- **`setup-*.ps1` 5 本の一覧**と、それぞれ何をどこにリンクするか
- **symlink 作成には管理者権限か開発者モードが必要**（無いと権限エラーで止まる）
- それらが冪等でなく `.config` の存在を前提にしていること（#280 へのリンク）
- **komorebi / whkd / yasb / AutoHotKey** — README に一度も登場していませんでした
- `powershell/komorebi-start.ps1` などの補助スクリプト
- **`Brewfile` 相当が無い**こと（scoop・direnv・poetry は手で入れる必要がある）
- **CI が Windows 上では何も実行していない**こと

`CLAUDE.md` も同様に更新しました。

## 補足

bats 44 pass、失敗 0。`actionlint` clean。

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_