### PR TITLE
feat(windows): make the setup scripts idempotent and add install.ps1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `make vscodeExtensions` — sync VSCode extensions via `configs/.vscode/vscodeSync.sh`
 - `make list` — show which dotfiles will be symlinked
 - `make help` — print all make targets
-- Windows setup: run `./bootstrap.ps1` to point the PowerShell `$PROFILE` at `windows/*.ps1` in the clone; the `setup-*.ps1` scripts symlink the remaining configs and need Developer Mode or an elevated shell; `setup-defaults.ps1` applies one-time machine settings (key repeat) and is not part of the profile
+- Windows setup: run `./install.ps1` (counterpart of `install.sh`) — it calls `bootstrap.ps1` to point the PowerShell `$PROFILE` at `windows/*.ps1` in the clone, the `setup-*.ps1` link scripts, and `setup-defaults.ps1` for one-time machine settings. Symlinks need Developer Mode or an elevated shell. Linking helpers live in `powershell/DotfilesSetup.ps1`, deliberately outside `windows/` since that is sourced into every shell
 
 ## CI
 
@@ -29,7 +29,7 @@ This is a cross-platform dotfiles repo (macOS, Linux/WSL, Windows). The core mec
 - `.config/fish/` — Fish shell config (experimental, best-effort). zsh is the source of truth for aliases and functions; fish carries only a subset. An alias defined in both shells must behave identically — add it to the matching `.zsh/*.zsh` module first
 - `configs/.vscode/` — VSCode settings, keybindings, and extension sync script
 - `.scripts/` — custom CLI tools added to PATH (`duck`, `google`, `pmux`, `git-worktree-pull`)
-- `powershell/` — komorebi window manager start/stop scripts
+- `powershell/` — komorebi start/stop scripts, and `DotfilesSetup.ps1` (the symlink helper the `setup-*.ps1` scripts share). Kept out of `windows/`, which `bootstrap.ps1` sources into every shell
 - `ahk/` — AutoHotKey scripts (remap keys, language switching, shortcuts)
 - `keymaps/` — custom keyboard layout mappings
 - `.config/kitty/`, `.config/hypr/`, `.config/i3/`, `.config/waybar/` — terminal and WM configs

--- a/README.md
+++ b/README.md
@@ -33,55 +33,54 @@ make config     # symlink .config entries
 
 ## Windows
 
-Run `bootstrap.ps1` to point the PowerShell profile at this repository:
+One command on a new machine:
 
 ```
-./bootstrap.ps1
+git clone https://github.com/Naturalclar/dotfiles.git; cd dotfiles; .\install.ps1
 ```
 
-It writes a `$PROFILE` that sources `windows/*.ps1` from the clone, in filename
-order — the same idea as the symlinks `make` creates on Unix. A `git pull` takes
-effect on the next shell, so this only needs running once per machine. Edit
-`windows/*.ps1` here rather than `$PROFILE`, which is overwritten.
-
-Any profile you already had is copied to `$PROFILE.bak` first. Re-running is
-safe: it will not overwrite that backup with the generated loader.
-
-### Everything else on Windows
-
-`bootstrap.ps1` only sets up the shell. The rest is separate scripts, each
-creating one symlink:
-
-| Script | Links |
-| --- | --- |
-| `setup-nvim.ps1` | `.config/nvim` → `%USERPROFILE%\AppData\Local\nvim` |
-| `setup-wezterm.ps1` | `.wezterm.lua` → `%USERPROFILE%` |
-| `setup-komorebi.ps1` | `.config/komorebi/*.json` → `%USERPROFILE%\.config` |
-| `setup-whkdrc.ps1` | `.config/whkdrc` → `%USERPROFILE%\.config` |
-| `setup-yasb.ps1` | `.yasb` → `%USERPROFILE%` |
-
-One more is not a symlink: `setup-defaults.ps1` applies the machine settings —
-key repeat and the persistent `PROMPT` variable. Run it once per machine. It is
-the Windows counterpart of the `defaults write` step in `install.sh`, and it is
-deliberately *not* in the profile: it writes to the registry, which has no
-business happening on every shell start.
+`install.ps1` is the counterpart of `install.sh`: it points the PowerShell
+profile at the clone, links the configs, and applies the machine settings. It is
+idempotent, so re-running is safe.
 
 **Creating symlinks on Windows needs either an elevated shell or Developer Mode**
-(Settings → Privacy & security → For developers). Without one of those,
-`New-Item -ItemType SymbolicLink` fails with a permissions error.
+(Settings → Privacy & security → For developers). Without one of those the link
+steps warn and carry on, rather than stopping the run.
 
-These are not idempotent yet and assume `%USERPROFILE%\.config` already exists —
-see #280.
+### What it runs
 
-The window-manager side is [komorebi](https://github.com/LGUG2Z/komorebi) with
+| Script | Does |
+| --- | --- |
+| `bootstrap.ps1` | Writes a `$PROFILE` that sources `windows/*.ps1` from the clone |
+| `setup-nvim.ps1` | Links `.config/nvim` → `%LOCALAPPDATA%\nvim` |
+| `setup-wezterm.ps1` | Links `.wezterm.lua` → `%USERPROFILE%` |
+| `setup-komorebi.ps1` | Links `.config/komorebi/*.json` → `%USERPROFILE%\.config` |
+| `setup-whkdrc.ps1` | Links `.config/whkdrc` → `%USERPROFILE%\.config` |
+| `setup-yasb.ps1` | Links `.yasb` → `%USERPROFILE%` |
+| `setup-defaults.ps1` | Key repeat and the persistent `PROMPT` variable |
+
+Each runs standalone too. Linking follows the same rule as `make` on Unix: a
+link we made before is replaced, and anything else already at the destination is
+left alone with a warning.
+
+`setup-ahk.ps1` links `ahk/*.ahk` into the Startup folder so they run at login —
+remapping Windows to Ctrl, switching input language, and a few shortcuts.
+`install.ps1` does **not** call it, since whether those should start
+automatically is a choice rather than part of setting the machine up.
+
+The profile is a loader, not a copy: a `git pull` takes effect on the next
+shell. Edit `windows/*.ps1` here rather than `$PROFILE`, which is overwritten.
+Any profile you already had is copied to `$PROFILE.bak` first, once.
+
+### Other pieces
+
+The window manager is [komorebi](https://github.com/LGUG2Z/komorebi) with
 [whkd](https://github.com/LGUG2Z/whkd) for hotkeys and
 [yasb](https://github.com/amnweb/yasb) for the status bar;
 `powershell/komorebi-start.ps1` and `komorebi-stop.ps1` (plus `.bat` wrappers)
-drive it. `ahk/` holds AutoHotKey scripts for remapping Windows to Ctrl,
-switching input language, and a few shortcuts — there is no setup script for
-those, so place them in the startup folder yourself.
+drive it.
 
-There is no `Brewfile` equivalent: the tools above, plus whatever
+There is no `Brewfile` equivalent: those tools, plus whatever
 `windows/path.ps1` expects (scoop, direnv, poetry), have to be installed by
 hand.
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,35 @@
+# install.ps1 -- one-command setup for a new Windows machine.
+#
+#   git clone https://github.com/Naturalclar/dotfiles.git; cd dotfiles; .\install.ps1
+#
+# The counterpart of install.sh. Idempotent: every step either replaces a link
+# it made before or leaves what it finds alone, so re-running is safe.
+#
+# Creating symlinks needs an elevated shell or Developer Mode
+# (Settings > Privacy & security > For developers). Without one, the link steps
+# warn and carry on rather than stopping the run.
+#
+# setup-ahk.ps1 is not called from here -- see the note in that file.
+
+$ErrorActionPreference = 'Stop'
+
+function Invoke-Step {
+    param([Parameter(Mandatory)][string]$Script)
+
+    Write-Host ''
+    Write-Host "==> $Script" -ForegroundColor Cyan
+    & (Join-Path $PSScriptRoot $Script)
+}
+
+# The profile first, so a new shell picks everything else up.
+Invoke-Step 'bootstrap.ps1'
+
+foreach ($script in 'setup-nvim.ps1', 'setup-wezterm.ps1', 'setup-komorebi.ps1',
+                    'setup-whkdrc.ps1', 'setup-yasb.ps1') {
+    Invoke-Step $script
+}
+
+Invoke-Step 'setup-defaults.ps1'
+
+Write-Host ''
+Write-Host 'Done. Start a new PowerShell to pick up the profile.'

--- a/powershell/DotfilesSetup.ps1
+++ b/powershell/DotfilesSetup.ps1
@@ -1,0 +1,60 @@
+# Shared helper for the setup-*.ps1 scripts.
+#
+# Deliberately not under windows/, since bootstrap.ps1 wires everything there
+# into $PROFILE and this has no business running on every shell start.
+
+Set-StrictMode -Version Latest
+
+function Test-IsSymbolicLink {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+    if ($null -eq $item) { return $false }
+    return $item.Attributes.HasFlag([IO.FileAttributes]::ReparsePoint)
+}
+
+<#
+.SYNOPSIS
+Link $Path to $Target, the way `ln -sfn` does on the Unix side.
+
+.DESCRIPTION
+Creates the parent directory if it is missing, replaces a link we previously
+made, and refuses to touch anything else that is already there -- the same rule
+`make dotfiles` follows since #264. Returns $true when the link is in place.
+#>
+function New-DotfilesLink {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Target
+    )
+
+    if (-not (Test-Path -LiteralPath $Target)) {
+        Write-Warning "skip $Path`: $Target does not exist in the repository"
+        return $false
+    }
+
+    # New-Item does not create intermediate directories for a symlink, and
+    # %USERPROFILE%\.config does not exist on a stock Windows install.
+    $parent = Split-Path -Parent $Path
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+
+    if ((Test-Path -LiteralPath $Path) -and -not (Test-IsSymbolicLink $Path)) {
+        Write-Warning "skip $Path`: already exists and is not a link -- move it aside first"
+        return $false
+    }
+
+    try {
+        New-Item -ItemType SymbolicLink -Path $Path -Value $Target -Force | Out-Null
+    } catch {
+        Write-Warning "failed to link $Path -> $Target"
+        Write-Warning 'Creating symlinks needs an elevated shell, or Developer Mode:'
+        Write-Warning '  Settings > Privacy & security > For developers > Developer Mode'
+        Write-Warning $_.Exception.Message
+        return $false
+    }
+
+    Write-Host "linked $Path -> $Target"
+    return $true
+}

--- a/setup-ahk.ps1
+++ b/setup-ahk.ps1
@@ -1,0 +1,11 @@
+# Link the AutoHotKey scripts into the Startup folder, so they run at login.
+#
+# Not called by install.ps1: whether these should start automatically is a
+# choice, not part of setting the machine up. Run it yourself if you want them.
+. "$PSScriptRoot\powershell\DotfilesSetup.ps1"
+
+$startup = [Environment]::GetFolderPath('Startup')
+
+foreach ($script in Get-ChildItem -Path "$PSScriptRoot\ahk" -Filter *.ahk) {
+    New-DotfilesLink -Path (Join-Path $startup $script.Name) -Target $script.FullName | Out-Null
+}

--- a/setup-komorebi.ps1
+++ b/setup-komorebi.ps1
@@ -1,8 +1,7 @@
-# create symbolic link for komorebi config file
+# Link the komorebi window-manager configs into ~/.config.
+. "$PSScriptRoot\powershell\DotfilesSetup.ps1"
 
-$configDir = "$env:USERPROFILE\.config\komorebi.json"
-$barConfigDir = "$env:USERPROFILE\.config\komorebi.bar.json"
-
-New-Item -ItemType SymbolicLink -Path $configDir -Value $PSScriptRoot\.config\komorebi\.komorebi.json
-New-Item -ItemType SymbolicLink -Path $barConfigDir -Value $PSScriptRoot\.config\komorebi\.komorebi.bar.json
-
+New-DotfilesLink -Path "$env:USERPROFILE\.config\komorebi.json" `
+    -Target "$PSScriptRoot\.config\komorebi\.komorebi.json" | Out-Null
+New-DotfilesLink -Path "$env:USERPROFILE\.config\komorebi.bar.json" `
+    -Target "$PSScriptRoot\.config\komorebi\.komorebi.bar.json" | Out-Null

--- a/setup-nvim.ps1
+++ b/setup-nvim.ps1
@@ -1,6 +1,4 @@
-# create symbolic link for nvim config directory
+# Link the Neovim config into %LOCALAPPDATA%.
+. "$PSScriptRoot\powershell\DotfilesSetup.ps1"
 
-$nvimDir = "$env:USERPROFILE\AppData\Local\nvim"
-
-New-Item -ItemType SymbolicLink -Path $nvimDir -Value $PSScriptRoot\.config\nvim
-
+New-DotfilesLink -Path "$env:USERPROFILE\AppData\Local\nvim" -Target "$PSScriptRoot\.config\nvim" | Out-Null

--- a/setup-wezterm.ps1
+++ b/setup-wezterm.ps1
@@ -1,6 +1,4 @@
-# create symbolic link for wezterm config file
+# Link the WezTerm config into the home directory.
+. "$PSScriptRoot\powershell\DotfilesSetup.ps1"
 
-$configDir = "$env:USERPROFILE\.wezterm.lua"
-
-New-Item -ItemType SymbolicLink -Path $configDir -Value $PSScriptRoot\.wezterm.lua
-
+New-DotfilesLink -Path "$env:USERPROFILE\.wezterm.lua" -Target "$PSScriptRoot\.wezterm.lua" | Out-Null

--- a/setup-whkdrc.ps1
+++ b/setup-whkdrc.ps1
@@ -1,6 +1,4 @@
-# create symbolic link for komorebi config file
+# Link the whkd hotkey config into ~/.config.
+. "$PSScriptRoot\powershell\DotfilesSetup.ps1"
 
-$whkdrcDir = "$env:USERPROFILE\.config\whkdrc"
-
-
-New-Item -ItemType SymbolicLink -Path $whkdrcDir -Value $PSScriptRoot\.config\whkdrc
+New-DotfilesLink -Path "$env:USERPROFILE\.config\whkdrc" -Target "$PSScriptRoot\.config\whkdrc" | Out-Null

--- a/setup-yasb.ps1
+++ b/setup-yasb.ps1
@@ -1,6 +1,4 @@
-# create symbolic link for yasb config file
+# Link the yasb status-bar config into the home directory.
+. "$PSScriptRoot\powershell\DotfilesSetup.ps1"
 
-$configDir = "$env:USERPROFILE\.yasb"
-
-New-Item -ItemType SymbolicLink -Path $configDir -Value $PSScriptRoot\.yasb
-
+New-DotfilesLink -Path "$env:USERPROFILE\.yasb" -Target "$PSScriptRoot\.yasb" | Out-Null


### PR DESCRIPTION
Closes #280。

## 再現した不具合

pwsh で 2 つとも実測しました。

**1. 再実行できない**（`-Force` が無い）

```
1 回目: OK
2 回目: 失敗: Cannot create link because the path already exists: .../link
```

**2. `.config` が無いと失敗する**（`setup-komorebi.ps1` と `setup-whkdrc.ps1`）

```
失敗: No such file or directory
```

Windows には `%USERPROFILE%\.config` が標準で存在しないので、まっさらな環境では通りません。#259 と同じ形です。

## 変更内容

### `powershell/DotfilesSetup.ps1`（新規）

リンク処理を `New-DotfilesLink` に集約しました。**`windows/` には置いていません** — そこは `bootstrap.ps1` が `$PROFILE` に読み込むので、ヘルパー定義が毎回のシェル起動で走ってしまうためです。

挙動:

| 状況 | 結果 |
| --- | --- |
| 親ディレクトリが無い | 作ってからリンク |
| 既にこちらが作ったリンク | 張り替える（再実行可能） |
| 既存の実ファイル / 実ディレクトリ | **触らずに警告** — `make dotfiles` が #264 以降やっているのと同じ規則 |
| リポジトリ側に対象が無い | 警告してスキップ |
| 権限不足 | **Developer Mode の場所を示す**メッセージ（素の例外ではなく） |

4 パターンとも pwsh で動作確認済みです。

```
--- 1. 親ディレクトリが無い場合 ---
linked .../home/.config/thing -> .../repo/thing.conf
  親が作られた: True
--- 2. 再実行（冪等性）---
linked .../home/.config/thing -> .../repo/thing.conf
--- 3. 既存の実ファイルがある場合（触らない）---
WARNING: skip .../home/mine.conf: already exists and is not a link -- move it aside first
  中身は保持されたか: my own file
--- 4. リポジトリ側に無いものを指定 ---
WARNING: skip .../home/nope: ... does not exist in the repository
```

### `install.ps1`（新規）

`install.sh` の対になる入り口です。これまで Windows は **6 本のスクリプトを自力で見つけて正しい順に実行**する必要があり、README も `bootstrap.ps1` しか案内していませんでした。

```
git clone https://github.com/Naturalclar/dotfiles.git; cd dotfiles; .\install.ps1
```

権限不足でリンクに失敗しても、警告を出して**残りは続行**します（そこで全部止まるより良いため）。

### `setup-ahk.ps1`（新規）

`ahk/*.ahk` をスタートアップフォルダにリンクします。これまで配置手段が一切ありませんでした。

**`install.ps1` からは呼んでいません。** これらをログイン時に自動起動させるかどうかは好みの問題で、マシンのセットアップの一部とは言えないためです。使いたければ個別に実行してください。

### 各 `setup-*.ps1`

ヘルパーを呼ぶだけの薄い形にしました。単体でも従来どおり実行できます。

## ドキュメント

README の Windows セクションを `install.ps1` 中心に書き直し、各スクリプトが何をリンクするかの表、Developer Mode の必要性、`setup-ahk.ps1` を意図的に自動実行しない理由を明記しました。`CLAUDE.md` も更新しています。

## 未検証の点

**Windows 実機では未検証です。** 検証は Linux の pwsh で行っており、シンボリックリンク作成そのものは動きますが、以下は実機でしか確認できません。

- 権限不足時のエラーメッセージ（Linux では権限エラーにならないため、catch 節は通っていません）
- `[Environment]::GetFolderPath('Startup')` が返すパス
- `setup-defaults.ps1` のレジストリ書き込み（#281 から引き続き）

`install.ps1` を一度流していただけると確実です。既存の設定は壊さない作りにしてあります（実ファイルは触らず警告、プロファイルは `.bak` に退避）。

## 補足

全 `.ps1` パース OK、`actionlint` clean、bats 44 pass。

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_