### PR TITLE
fix(windows): repair the broken aliases and align them with zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ If you touch aliases:
 - Add or change them in the matching `.zsh/*.zsh` module first.
 - Porting to fish is optional — but **a name that exists in both shells must behave identically**. A name that means one thing in zsh and another in fish is worse than not having it in fish at all.
 
-`test/aliases.bats` enforces that in CI. It compares aliases textually, and — because a name can be an alias in one shell and a function in the other, where there is nothing to compare across two different syntaxes — it also requires any such pair to be listed in `KNOWN_EQUIVALENT` with a note saying it was checked by hand. A new mismatched pair therefore cannot appear unnoticed. It also fails if an alias is defined twice across the modules (where the later definition silently wins).
+PowerShell (`windows/alias.ps1`) follows the same rule for the definitions that
+can be compared at all — the one-liners. Its prompt mirrors the zsh one too.
+Anything genuinely platform-specific (`open` is `explorer.exe` under WSL and
+`Invoke-Item` in PowerShell) is recorded as a known difference rather than
+forced to match.
+
+`test/aliases.bats` enforces that in CI. It compares aliases textually, and — because a name can be an alias in one shell and a function in the other, where there is nothing to compare across two different syntaxes — it also requires any such pair to be listed in `KNOWN_EQUIVALENT` with a note saying it was checked by hand. A new mismatched pair therefore cannot appear unnoticed. It also fails if an alias is defined twice across the modules (where the later definition silently wins), and it rejects two PowerShell mistakes that cannot work: a `Set-Alias` carrying arguments (`Set-Alias pb "pnpm build"` aliases a command *named* `pnpm build`, which does not exist) and a `Set-Alias` whose value contains `$( )`, which runs once at profile load rather than when the command is used.
 
 Both shells use vi key bindings (`set -o vi` in zsh, `fish_key_bindings` in fish) and export `EDITOR=vim` and `GIT_EDITOR=vim`.
 

--- a/test/aliases.bats
+++ b/test/aliases.bats
@@ -14,6 +14,7 @@
 
 # .zshrc is only a loader now; the definitions live in .zsh/*.zsh.
 ZSH_PARTS=("$BATS_TEST_DIRNAME"/../.zsh/*.zsh)
+PS_ALIASES="$BATS_TEST_DIRNAME/../windows/alias.ps1"
 FISH_DIR="$BATS_TEST_DIRNAME/../.config/fish"
 FISH_ALIASES="$FISH_DIR/conf.d/aliases.fish"
 
@@ -31,6 +32,14 @@ FISH_ALIASES="$FISH_DIR/conf.d/aliases.fish"
 #             preview string verbatim since fzf runs it with sh either way
 #   run-script  same selector, same lockfile order; rewritten in fish syntax
 KNOWN_EQUIVALENT="gbd gcod gpcb n run-script rundroid wf ws"
+
+# Same idea for PowerShell. Only the one-liners are comparable at all; anything
+# multi-line is rewritten in PowerShell and is not checked here.
+#
+#   gpcbf, gplcb  command substitution syntax, and zsh's git_current_branch is
+#                 spelled get_current_branch on the PowerShell side
+#   open          zsh runs explorer.exe under WSL; PowerShell has Invoke-Item
+PS_KNOWN_EQUIVALENT="gpcbf gplcb open"
 
 # Print "name<TAB>definition" for every `alias name=...` line in $1. The
 # surrounding quotes and any trailing comment are stripped so that the two
@@ -58,6 +67,21 @@ fish_names() {
     grep -hoE "^[[:space:]]*alias [A-Za-z0-9_.:-]+=" "$FISH_DIR"/conf.d/*.fish | sed -E 's/^[[:space:]]*alias //; s/=$//'
     grep -hoE "^function [A-Za-z0-9_.:-]+" "$FISH_DIR"/conf.d/*.fish | sed 's/^function //'
     basename -s .fish "$FISH_DIR"/functions/*.fish
+  } | sort -u
+}
+
+# name<TAB>definition for the PowerShell one-liners: single-line functions with
+# the trailing $args forwarding removed, plus Set-Alias entries that take no
+# arguments. Set-Alias cannot carry arguments -- binding it to "pnpm build"
+# produces an alias for a command of that name, which does not exist -- so an
+# argument-carrying entry is a bug rather than something to compare.
+ps_defs() {
+  {
+    grep -oE "^Function [A-Za-z0-9_.-]+ \{ [^}]+ \}" "$PS_ALIASES" |
+      sed -E 's/^Function ([A-Za-z0-9_.-]+) \{ (.*) \}$/\1\t\2/' |
+      sed -E 's/[[:space:]]*\$args[[:space:]]*$//'
+    grep -oE "^Set-Alias -Name [A-Za-z0-9_.-]+ -Value [A-Za-z0-9_.-]+$" "$PS_ALIASES" |
+      sed -E 's/^Set-Alias -Name ([A-Za-z0-9_.-]+) -Value (.*)$/\1\t\2/'
   } | sort -u
 }
 
@@ -138,6 +162,49 @@ defined_as_alias() {
   done
   if [ -n "$stale" ]; then
     echo "KNOWN_EQUIVALENT lists names that are no longer in both shells:$stale"
+    false
+  fi
+}
+
+# --- PowerShell ---------------------------------------------------------------
+
+@test "no Set-Alias carries arguments" {
+  # Set-Alias binds a name to one command. Given "pnpm build" it makes an alias
+  # for a command called "pnpm build", which fails the moment it is run.
+  bad="$(grep -nE '^Set-Alias .* -Value "[^"]* ' "$PS_ALIASES" || true)"
+  if [ -n "$bad" ]; then
+    echo "these aliases can never run; make them functions instead:"
+    echo "$bad"
+    false
+  fi
+}
+
+@test "no Set-Alias expands a subshell at load time" {
+  # $( ) inside a double-quoted value runs when the profile loads, freezing the
+  # result -- which for gpcbf meant force-pushing to whatever branch was checked
+  # out when the shell opened.
+  bad="$(grep -nE '^Set-Alias .*\$\(' "$PS_ALIASES" || true)"
+  if [ -n "$bad" ]; then
+    echo "these evaluate at profile load rather than when run:"
+    echo "$bad"
+    false
+  fi
+}
+
+@test "PowerShell definition extraction finds the one-liners" {
+  [ "$(ps_defs | wc -l)" -gt 30 ]
+  ps_defs | grep -qx "$(printf 'gbr\tgit branch')"
+}
+
+@test "a name defined in zsh and PowerShell means the same thing" {
+  conflicts="$(join -t$'\t' \
+    <(alias_defs "${ZSH_PARTS[@]}" | sort -u -t$'\t' -k1,1) \
+    <(ps_defs | sort -u -t$'\t' -k1,1) |
+    awk -F'\t' -v known=" $PS_KNOWN_EQUIVALENT " \
+      '$2 != $3 && index(known, " " $1 " ") == 0 { printf "%s\n  zsh: %s\n  ps:  %s\n", $1, $2, $3 }')"
+  if [ -n "$conflicts" ]; then
+    echo "these disagree between zsh and PowerShell (.zsh/*.zsh is the source of truth):"
+    echo "$conflicts"
     false
   fi
 }

--- a/windows/alias.ps1
+++ b/windows/alias.ps1
@@ -86,53 +86,74 @@ Set-Alias -Name lg -Value lazygit
 
 $Env:KOMOREBI_CONFIG_HOME = "$Env:USERPROFILE\.config"
 
-# Add aliases for pnpm commands
+# NOTE: these are functions, not Set-Alias. Set-Alias binds a name to a single
+# command, so `Set-Alias pb "pnpm build"` creates an alias for a command called
+# "pnpm build" -- which does not exist, and fails the moment you run it. Only
+# argument-less aliases (below) can use Set-Alias.
+#
+# Definitions follow .zsh/*.zsh, which is the source of truth. See README.md.
+
+# pnpm
 Set-Alias -Name p -Value pnpm
-Set-Alias -Name pb -Value "pnpm build"
-Set-Alias -Name ph -Value "pnpm start"
-Set-Alias -Name pi -Value "pnpm install"
-Set-Alias -Name add -Value "pnpm add"
-Set-Alias -Name addd -Value "pnpm add -D"
-Set-Alias -Name addg -Value "pnpm global add"
-Set-Alias -Name lint -Value "pnpm lint"
-Set-Alias -Name format -Value "pnpm format"
-Set-Alias -Name tc -Value "pnpm type-check"
-Set-Alias -Name type-check -Value "pnpm type-check"
-Set-Alias -Name ptc -Value "pnpm type:check"
+Function pb { pnpm build $args }
+Function ph { pnpm start $args }
+Function pi { pnpm install $args }
+Function add { pnpm add $args }
+Function addd { pnpm add -D $args }
+Function addg { pnpm global add $args }
+Function lint { pnpm lint $args }
+Function format { pnpm format $args }
+Function tc { pnpm type-check $args }
+Function ptc { pnpm type:check $args }
+# zsh has this one on yarn, not pnpm
+Function type-check { yarn type-check $args }
 
-# Add aliases for npx commands
-Set-Alias -Name upset -Value "npx git-upstream --set"
+# npx
+Function upset { npx git-upstream --set $args }
 
-# Add aliases for ghq commands
-Set-Alias -Name get -Value "ghq get"
-Set-Alias -Name getb -Value "ghq get --bare"
+# ghq -- `get` is defined as a function further up
+Function getb { ghq get --bare $args }
 
-# Add additional git aliases
-Set-Alias -Name gbr -Value "git branch"
-Set-Alias -Name gbranch -Value "git branch"
-Set-Alias -Name gcom -Value "git switch master"
-Set-Alias -Name gcp -Value "git cherry-pick"
-Set-Alias -Name gdm -Value "git branch --merged|egrep -v '\*|develop|master|release'|xargs git branch -d"
-Set-Alias -Name glog -Value "git log"
-Set-Alias -Name gpcbf -Value "git push origin $(get_current_branch) --force-with-lease"
-Set-Alias -Name gpom -Value "git push origin -u master"
-Set-Alias -Name gpl -Value "git pull"
-Set-Alias -Name gplcb -Value "git pull origin $(get_current_branch)"
-Set-Alias -Name gpsub -Value "git submodule update --init --recursive"
-Set-Alias -Name gptag -Value "git push origin --tags"
-Set-Alias -Name gpum -Value "git pull upstream master"
-Set-Alias -Name gr -Value "gcod && gpull"
-Set-Alias -Name grh -Value "git restore --worktree"
-Set-Alias -Name grb -Value "git rebase"
-Set-Alias -Name gsd -Value "git switch develop"
-Set-Alias -Name gsm -Value "git switch master"
-Set-Alias -Name gw -Value "git worktree"
-Set-Alias -Name gitsync -Value "git remote set-head origin --auto"
-Set-Alias -Name bl -Value "git branch"
-Set-Alias -Name branch -Value "git branch"
-Set-Alias -Name pull -Value "git pull"
-Set-Alias -Name up -Value "git pull upstream master"
-Set-Alias -Name get_default_branch_fast -Value "git symbolic-ref refs/remotes/origin/HEAD --short | sed 's/origin\///'"
+# git
+Function gbr { git branch $args }
+Function gbranch { git branch $args }
+Function bl { git branch $args }
+Function branch { git branch $args }
+Function gcom { git switch master }
+Function gsm { git switch master }
+Function gsd { git switch develop }
+Function gcp { git cherry-pick $args }
+Function glog { git log $args }
+Function grb { git rebase $args }
+Function grh { git restore --worktree $args }
+Function gw { git worktree $args }
+Function gpl { git pull $args }
+Function pull { git pull $args }
+Function gpom { git push origin -u master }
+Function gptag { git push origin --tags }
+Function gpum { git pull upstream master }
+Function gpsub { git submodule update --init --recursive }
+Function gitsync { git remote set-head origin --auto }
+Function gr { gcod && gpull }
+Function up { git stash -u && git rebase main && git stash pop }
+
+# The branch has to be resolved when the command runs. Inside a double-quoted
+# Set-Alias value $( ) expands once, at profile load, so these used to push to
+# whichever branch happened to be checked out when the shell opened.
+Function gpcbf { git push origin (get_current_branch) --force-with-lease $args }
+Function gplcb { git pull origin (get_current_branch) $args }
+
+# sed, egrep and xargs are not there on Windows, so these differ from the zsh
+# definitions in wording while doing the same thing.
+Function get_default_branch_fast {
+    (git symbolic-ref refs/remotes/origin/HEAD --short) -replace '^origin/', ''
+}
+Function gdm {
+    # delete merged branches
+    git branch --merged |
+        Where-Object { $_ -notmatch '^\*|develop|master|release' } |
+        ForEach-Object { git branch -d $_.Trim() }
+}
 
 # Add alias for cygpath
 Set-Alias cygpath "$env:USERPROFILE\scoop\apps\git\current\usr\bin\cygpath.exe"

--- a/windows/terminal.ps1
+++ b/windows/terminal.ps1
@@ -1,29 +1,71 @@
-# Set the shell to display current branch name
-function prompt {
-  $loc = $executionContext.SessionState.Path.CurrentLocation;
+# NOTE: mirrors _prompt_path in .zsh/40-prompt.zsh, which is the source of
+# truth, and __prompt_path.fish on the fish side. Inside a git repository show
+# <repo>[/<worktree>] plus the path from the repository root, instead of just
+# the directory name -- under ~/.ghq/github.com/owner/... a bare leaf tells you
+# very little, and with worktrees it is often just the branch name.
+function Get-PromptPath {
+    try {
+        $info = @(git rev-parse --show-toplevel --git-common-dir 2>$null)
+        if ($LASTEXITCODE -ne 0 -or $info.Count -ne 2) {
+            return $PWD.Path.Replace($HOME, '~')
+        }
 
-  $out = ""
-  if ($loc.Provider.Name -eq "FileSystem") {
-    $out += "$([char]27)]9;9;`"$($loc.ProviderPath)`"$([char]27)\"
-  }
-  $out += "PS> ";
-  # Get name of the current directory
-  $directoryName = (Get-Location).Path.Split("\")[-1]
-  $branch = $(get_current_branch)
+        # git reports forward slashes on Windows while $PWD uses backslashes,
+        # so normalise before taking the path relative to the root.
+        $root = $info[0] -replace '\\', '/'
+        $here = $PWD.Path -replace '\\', '/'
 
-  # Check if there are any changes in the current directory without showing them
-  $has_diff = $null -ne $(git status --porcelain)
-  if ($has_diff -eq "True") {
-      $branchColor = "Red"
-  }
-  else {
-      $branchColor = "Green"
-  }
-  Write-Host "╭─ " -NoNewline -ForegroundColor "DarkGreen"
-  Write-Host "$directoryName " -NoNewline -ForegroundColor "Magenta"
-  Write-Host "[$branch] " -ForegroundColor $branchColor
-  Write-Host "╰─$ " -NoNewline -ForegroundColor "DarkGreen"
+        # --git-common-dir is relative when called from a subdirectory.
+        $common = (Resolve-Path -LiteralPath $info[1]).Path -replace '\\', '/'
 
-  return $out
+        # .git or .bare means a hidden directory inside the repository, so the
+        # parent carries the name. Anything else is the bare repository itself
+        # (foo.git), whose own name is it, minus the suffix.
+        $leaf = Split-Path -Leaf $common
+        if ($leaf -in '.git', '.bare') {
+            $label = Split-Path -Leaf (Split-Path -Parent $common)
+        } else {
+            $label = $leaf -replace '\.git$', ''
+        }
+
+        # In a linked worktree <root>/.git is a file rather than a directory.
+        if (Test-Path -LiteralPath (Join-Path $info[0] '.git') -PathType Leaf) {
+            $label = "$label/" + (Split-Path -Leaf $root)
+        }
+
+        if ($here.Length -gt $root.Length) {
+            $label += $here.Substring($root.Length)
+        }
+        return $label
+    } catch {
+        # Never let the prompt break; fall back to what this used to show.
+        return (Split-Path -Leaf $PWD.Path)
+    }
 }
 
+function prompt {
+    $loc = $executionContext.SessionState.Path.CurrentLocation
+
+    $out = ""
+    if ($loc.Provider.Name -eq "FileSystem") {
+        $out += "$([char]27)]9;9;`"$($loc.ProviderPath)`"$([char]27)\"
+    }
+    $out += "PS> "
+
+    $path = Get-PromptPath
+    $branch = get_current_branch
+
+    # Red when the working tree is dirty, matching the vcs_info markers in zsh.
+    $branchColor = if ($null -ne (git status --porcelain 2>$null)) { "Red" } else { "Green" }
+
+    Write-Host "╭─ " -NoNewline -ForegroundColor "DarkGreen"
+    Write-Host "$path " -NoNewline -ForegroundColor "Magenta"
+    if ($branch) {
+        Write-Host "[$branch] " -ForegroundColor $branchColor
+    } else {
+        Write-Host ""
+    }
+    Write-Host "╰─$ " -NoNewline -ForegroundColor "DarkGreen"
+
+    return $out
+}


### PR DESCRIPTION
Closes #282。

issue は「3 つ目の設定コピーでドリフト検知の対象外」という話でしたが、調べたところ**そもそも大半が動いていませんでした**。

## 48 個中 39 個の `Set-Alias` が実行不可能だった

`Set-Alias` は名前を**単一コマンド**に割り当てるものです。引数付きの文字列を渡すと「`pnpm build` という名前のコマンド」への別名になり、エイリアス自体は作れるものの**使った瞬間に失敗します**。pwsh で確認しました。

```
エイリアスは作れる: pnpm build
実行すると: The term 'pnpm build' is not recognized as a name of a cmdlet, ...
```

対象は `pb` `ph` `pi` `add` `addd` `addg` `lint` `format` `tc` `type-check` `ptc` `upset` `get` `getb` `gbr` `gbranch` `gcom` `gcp` `gdm` `glog` `gpcbf` `gpom` `gpl` `gplcb` `gpsub` `gptag` `gpum` `gr` `grh` `grb` `gsd` `gsm` `gw` `gitsync` `bl` `branch` `pull` `up` `get_default_branch_fast` の 39 個です。

正常に動いていたのは引数を取らない 9 個（`which` `touch` `open` `psh` `g` `vim` `tf` `lg` `p`）だけでした。

### うち 2 個は危険

```powershell
Set-Alias -Name gpcbf -Value "git push origin $(get_current_branch) --force-with-lease"
```

`$( )` はダブルクォート内なので**プロファイル読み込み時に一度だけ展開**されます。つまりシェルを開いた瞬間のブランチ名が焼き込まれ、**`gpcbf`（force push）が別のブランチを狙います**。これも実測しました。

```
[get_current_branch がプロファイル読み込み時に実行された]
定義: git push origin some-branch --force-with-lease
```

### 関数が隠されていた

`get` は Function として正しく定義されていたのに、後ろの壊れた `Set-Alias -Name get` に隠されていました（PowerShell ではエイリアスが関数より優先されます）。

## 変更内容

### 1. 全部 function に書き直し、定義は zsh から取った

これによりドリフトも同時に解消します。実際にズレていたもの:

| | zsh | PowerShell（旧） |
| --- | --- | --- |
| `up` | `git stash -u && git rebase main && git stash pop` | `git pull upstream master` |
| `gpull` | `git pull` | `git pull origin $args` |

`gdm` と `get_default_branch_fast` は `sed` / `egrep` / `xargs` に依存していたので PowerShell ネイティブに書き直しました（Windows には無いため、これも動いていませんでした）。

引数の受け渡しは、実在のネイティブコマンドに対して `$args` と `@args` が同じ挙動になることを確認したうえで `$args` に統一しています。

### 2. プロンプトを揃えた

これまで**カレントディレクトリ名だけ**でしたが、#268 / #270 と同じく **リポジトリ名 / worktree 名 / ルートからの相対パス** を出します。

```
旧: ╭─ components [main]
新: ╭─ dotfiles/main/src/components [main]
```

zsh 実装と **7 レイアウトすべてで一致**することを確認しました（通常 clone / サブディレクトリ / linked worktree / `.bare` 運用 / `foo.git` 運用 / ghq パス / リポジトリ外）。

例外が飛んだ場合は**従来の表示にフォールバック**します。プロンプトが壊れるのは避けたいためです。

### 3. ドリフト検知を PowerShell まで拡張

`test/aliases.bats` に 4 ケース追加しました。1 行 function と引数なし `Set-Alias` は zsh とテキスト比較できるので（`$args` を落とせば **36 個中 34 個が完全一致**）、そのまま比較します。

あわせて、上で見つけた 2 種類の間違いを**構造的に禁止**します。

- 引数付き `Set-Alias` → 失敗
- `$( )` を含む `Set-Alias` → 失敗

比較できない 3 件は理由付きで `PS_KNOWN_EQUIVALENT` に記録しています（`gpcbf` / `gplcb` は構文差、`open` は WSL の `explorer.exe` と PowerShell の `Invoke-Item` で**プラットフォーム的に正しい差**）。

わざと壊して 3 パターンとも落ちることを確認済みです。`gpull` のズレを再現させると:

```
not ok 10 a name defined in zsh and PowerShell means the same thing
# these disagree between zsh and PowerShell (.zsh/*.zsh is the source of truth):
# gpl
```

## 動作確認

- bats 48 pass、失敗 0（aliases 6 → 10 ケース）
- 全 `.ps1` パース OK
- 各 function が正しいコマンドに展開されることを、コマンドを stub して確認
- `(get_current_branch)` が**実行時に**解決されることを確認
- プロンプトの 7 レイアウト一致

## 未検証の点

Windows 実機では未検証です。とくに**プロンプトのパス正規化**（Windows では git が `/` を返し `$PWD` は `\` を使うので変換しています）はこの環境では通っていない経路です。フォールバックを入れてあるので最悪でも旧表示に戻るだけですが、確認していただけると確実です。

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_