### PR TITLE
feat(windows): mirror the shell keybindings in PowerShell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ This is a cross-platform dotfiles repo (macOS, Linux/WSL, Windows). The core mec
 - `configs/.vscode/` — VSCode settings, keybindings, and extension sync script
 - `.scripts/` — custom CLI tools added to PATH (`duck`, `google`, `pmux`, `git-worktree-pull`)
 - `powershell/` — komorebi start/stop scripts, and `DotfilesSetup.ps1` (the symlink helper the `setup-*.ps1` scripts share). Kept out of `windows/`, which `bootstrap.ps1` sources into every shell
+- `windows/*.ps1` — PowerShell profile parts, sourced in filename order by the `$PROFILE` loader `bootstrap.ps1` writes. `keybindings.ps1` mirrors the zsh keybinds via PSReadLine; `functions.ps1` holds what they call
 - `ahk/` — AutoHotKey scripts (remap keys, language switching, shortcuts)
 - `keymaps/` — custom keyboard layout mappings
 - `.config/kitty/`, `.config/hypr/`, `.config/i3/`, `.config/waybar/` — terminal and WM configs

--- a/README.md
+++ b/README.md
@@ -109,9 +109,22 @@ forced to match.
 
 `test/aliases.bats` enforces that in CI. It compares aliases textually, and — because a name can be an alias in one shell and a function in the other, where there is nothing to compare across two different syntaxes — it also requires any such pair to be listed in `KNOWN_EQUIVALENT` with a note saying it was checked by hand. A new mismatched pair therefore cannot appear unnoticed. It also fails if an alias is defined twice across the modules (where the later definition silently wins), and it rejects two PowerShell mistakes that cannot work: a `Set-Alias` carrying arguments (`Set-Alias pb "pnpm build"` aliases a command *named* `pnpm build`, which does not exist) and a `Set-Alias` whose value contains `$( )`, which runs once at profile load rather than when the command is used.
 
-Both shells use vi key bindings (`set -o vi` in zsh, `fish_key_bindings` in fish) and export `EDITOR=vim` and `GIT_EDITOR=vim`.
+All three shells use vi key bindings (`set -o vi` in zsh, `fish_key_bindings` in fish, `Set-PSReadLineOption -EditMode Vi` in PowerShell) and export `EDITOR=vim` and `GIT_EDITOR=vim`.
 
-Keybindings are mirrored too: `Ctrl+R`/`Ctrl+Z` history search, `Ctrl+W`/`Ctrl+A` ghq repo pickers, `Ctrl+F` tmux session, `Ctrl+B` git worktree, `Ctrl+N` package.json script. Several of them take over a fish default (`Ctrl+A` beginning-of-line, `Ctrl+F` accept-autosuggestion, `Ctrl+W` backward-kill-word), which is deliberate — the point is for the two shells to feel the same.
+Keybindings are mirrored too:
+
+| Key | Does | zsh | fish | PowerShell |
+| --- | --- | --- | --- | --- |
+| `Ctrl+R` / `Ctrl+Z` | history search | ✓ | ✓ | ✓ |
+| `Ctrl+W` | ghq repo (peco) | ✓ | ✓ | ✓ |
+| `Ctrl+A` | ghq repo (fzf) | ✓ | ✓ | ✓ |
+| `Ctrl+B` | git worktree | ✓ | ✓ | ✓ |
+| `Ctrl+N` | package.json script | ✓ | ✓ | ✓ |
+| `Ctrl+F` | tmux session (`pmux`) | ✓ | ✓ | — |
+
+`Ctrl+F` has no PowerShell binding because there is no tmux there. `Ctrl+A` on Windows picks without the README preview, since fzf runs its preview through cmd and the Unix version leans on `find` and `bat`.
+
+Several of these take over a default (`Ctrl+A` beginning-of-line, `Ctrl+F` accept-autosuggestion in fish, `Ctrl+W` backward-kill-word), which is deliberate — the point is for the shells to feel the same. In fish and PowerShell they are bound in both vi modes, so they work whether or not you are in insert mode.
 
 The prompt is the one place where fish deliberately carries a copy of zsh logic: `.config/fish/functions/__prompt_path.fish` mirrors `_prompt_path` in `.zsh/40-prompt.zsh`, and `__prompt_git_state.fish` mirrors the `vcs_info` zstyles. `test/prompt.bats` runs both implementations over the same repository layouts and fails if they disagree.
 

--- a/windows/functions.ps1
+++ b/windows/functions.ps1
@@ -1,0 +1,82 @@
+# Functions behind the keybindings in keybindings.ps1. Same jobs as the zsh
+# widgets in .zsh/73-workspace.zsh, .zsh/74-peco-fzf.zsh and
+# .zsh/81-run-script.zsh -- see README.md, zsh is the source of truth.
+
+# Ctrl+A. zsh previews the README with find+bat, which are not here; fzf on
+# Windows runs its preview through cmd, so this picks without one. `ws`
+# (Ctrl+W, in alias.ps1) is the peco equivalent.
+Function wf {
+    $repo = ghq list --full-path | fzf --layout=reverse
+    if ($repo) { Set-Location $repo }
+}
+
+# Ctrl+B. .scripts/switch-worktree is bash and has to be sourced to cd, which
+# PowerShell cannot do, so this is the equivalent.
+Function switch-worktree {
+    $lines = @(git worktree list 2>$null | Select-Object -Skip 1)
+    if ($lines.Count -eq 0) {
+        Write-Host "No linked worktrees for this repository"
+        return
+    }
+
+    $entries = foreach ($line in $lines) {
+        $fields = $line -split '\s+'
+        $path = $fields[0]
+        $branch = $fields[2] -replace '^\[|\]$', ''
+        $name = Split-Path -Leaf $path
+        # "Nothing" when the branch adds nothing beyond the directory name,
+        # matching the bash script.
+        if ($branch -eq $name) { $branch = 'Nothing' }
+        [pscustomobject]@{
+            Path  = $path
+            Label = '{0,-30} {1}' -f ((Split-Path -Leaf (Split-Path -Parent $path)) + "/$name"), $branch
+        }
+    }
+
+    $picked = $entries.Label | fzf --layout=reverse --prompt="Select worktree: "
+    if (-not $picked) { return }
+
+    $match = $entries | Where-Object { $_.Label -eq $picked } | Select-Object -First 1
+    if ($match) { Set-Location $match.Path }
+}
+
+# Ctrl+N. Same selector and lockfile precedence as the zsh and fish versions,
+# using ConvertFrom-Json rather than jq, which Windows does not ship.
+Function run-script {
+    if (-not (Test-Path -LiteralPath 'package.json')) {
+        Write-Host "No package.json found in current directory"
+        return
+    }
+
+    $scripts = (Get-Content -Raw 'package.json' | ConvertFrom-Json).scripts
+    if (-not $scripts) {
+        Write-Host "No scripts found in package.json"
+        return
+    }
+
+    # ::: as the delimiter, so script names containing a colon still split.
+    $entries = $scripts.PSObject.Properties | ForEach-Object { "$($_.Name):::$($_.Value)" }
+    $picked = $entries | fzf --layout=reverse --prompt="Run script: "
+    if (-not $picked) { return }
+
+    $name = ($picked -split ':::', 2)[0]
+
+    $cmd = 'npm', 'run'
+    if (Test-Path -LiteralPath 'yarn.lock') { $cmd = , 'yarn' }
+    elseif (Test-Path -LiteralPath 'pnpm-lock.yaml') { $cmd = , 'pnpm' }
+    elseif (Test-Path -LiteralPath 'bun.lockb') { $cmd = 'bun', 'run' }
+
+    Write-Host "Running: $($cmd -join ' ') $name"
+    & $cmd[0] @($cmd[1..($cmd.Count - 1)]) $name
+}
+
+# Ctrl+R / Ctrl+Z. zsh reverses its history, drops duplicates and pipes it to
+# peco; PSReadLine keeps its own history file, so read that instead.
+Function Select-HistoryLine {
+    $path = (Get-PSReadLineOption).HistorySavePath
+    if (-not (Test-Path -LiteralPath $path)) { return }
+
+    $lines = [System.Collections.ArrayList]@(Get-Content -LiteralPath $path)
+    $lines.Reverse()
+    return $lines | Select-Object -Unique | peco
+}

--- a/windows/keybindings.ps1
+++ b/windows/keybindings.ps1
@@ -1,0 +1,67 @@
+# NOTE: mirrors the bindkey lines in .zsh/ and fish_user_key_bindings in fish.
+# zsh is the source of truth -- see README.md.
+#
+# Ctrl+F is deliberately absent: it opens a tmux session on the Unix side, and
+# there is no tmux here.
+
+if (-not (Get-Module PSReadLine)) {
+    Import-Module PSReadLine -ErrorAction SilentlyContinue
+}
+if (-not (Get-Module PSReadLine)) { return }
+
+# zsh runs `set -o vi` and fish pins fish_vi_key_bindings; match them.
+Set-PSReadLineOption -EditMode Vi
+
+# Bind in both vi modes, as the fish side does, so these work whether or not
+# you are in insert mode. Without -ViMode only insert gets the binding.
+function Set-Binding {
+    param(
+        [Parameter(Mandatory)][string]$Chord,
+        [Parameter(Mandatory)][scriptblock]$Action,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    foreach ($mode in 'Insert', 'Command') {
+        Set-PSReadLineKeyHandler -Chord $Chord -ScriptBlock $Action `
+            -Description $Description -ViMode $mode
+    }
+}
+
+# Replace the line with a command picked out of history.
+Set-Binding -Chord 'Ctrl+r' -Description 'search history' -Action {
+    $picked = Select-HistoryLine
+    if ($picked) {
+        [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+        [Microsoft.PowerShell.PSConsoleReadLine]::Insert($picked)
+    }
+}
+# zsh had history on Ctrl+Z first; keep it there too.
+Set-PSReadLineKeyHandler -Chord 'Ctrl+z' -ViMode Insert -Description 'search history' -ScriptBlock {
+    $picked = Select-HistoryLine
+    if ($picked) {
+        [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+        [Microsoft.PowerShell.PSConsoleReadLine]::Insert($picked)
+    }
+}
+
+# These change directory, so redraw the prompt afterwards rather than leaving
+# the old one on screen.
+Set-Binding -Chord 'Ctrl+w' -Description 'ghq repo (peco)' -Action {
+    ws
+    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+}
+Set-Binding -Chord 'Ctrl+a' -Description 'ghq repo (fzf)' -Action {
+    wf
+    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+}
+Set-Binding -Chord 'Ctrl+b' -Description 'git worktree' -Action {
+    switch-worktree
+    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+}
+
+# Runs a command rather than moving, so let it print above a fresh prompt.
+Set-Binding -Chord 'Ctrl+n' -Description 'package.json script' -Action {
+    [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
+    run-script
+    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+}


### PR DESCRIPTION
zsh と fish は #272 / #274 でキーバインドと vi モードを揃えましたが、PowerShell は**どれも入っておらず emacs 編集モードのまま**でした。PSReadLine で揃えます。

## 対応表

| キー | 動作 | zsh | fish | PowerShell |
| --- | --- | --- | --- | --- |
| `Ctrl+R` / `Ctrl+Z` | 履歴検索 | ✓ | ✓ | **✓ 追加** |
| `Ctrl+W` | ghq リポジトリ（peco） | ✓ | ✓ | **✓ 追加** |
| `Ctrl+A` | ghq リポジトリ（fzf） | ✓ | ✓ | **✓ 追加** |
| `Ctrl+B` | git worktree | ✓ | ✓ | **✓ 追加** |
| `Ctrl+N` | package.json スクリプト | ✓ | ✓ | **✓ 追加** |
| `Ctrl+F` | tmux セッション（`pmux`） | ✓ | ✓ | — |

あわせて **vi モード**（`Set-PSReadLineOption -EditMode Vi`）も有効にしました。

## `windows/keybindings.ps1`（新規）

**両方の vi モードに登録**しています。これが重要で、`-ViMode` を指定しないと **Insert モードにしか入りません**。実測で確認しました。

```
=== -ViMode 指定なし ===
  <Ctrl+w> -> BackwardDeleteWord   ← Command モードは既定のまま
  Ctrl+w   -> CustomAction
```

つまり指定を省くと、Insert モードを抜けた瞬間にバインドが効かなくなります。fish で `-M default insert` の両方に入れたのと同じ理由です。

ディレクトリを移動するものは `InvokePrompt()` でプロンプトを再描画し、`Ctrl+N` は `RevertLine()` してから実行するようにしています。

## `windows/functions.ps1`（新規）

バインド先のうち、PowerShell に存在しなかったものを実装しました（`ws` は既存）。

- **`run-script`** — セレクタもロックファイルの優先順位も他 2 シェルと同じ。`jq` は Windows に無いので `ConvertFrom-Json` を使用
- **`switch-worktree`** — `.scripts/switch-worktree` は bash かつ `cd` のため source 前提で、PowerShell からは使えないので書き直し
- **`wf`** — fzf 版のリポジトリ選択
- **`Select-HistoryLine`** — PSReadLine の履歴ファイルを peco に流す（zsh は zsh 履歴を使うので、そこだけ実装が異なります）

## 意図的に揃えていない 2 点

- **`Ctrl+F`** — `pmux` は tmux セッションを作るもので、Windows に tmux はありません
- **`Ctrl+A` のプレビュー** — Unix 版は `find` と `bat` に依存し、fzf は Windows ではプレビューを cmd で実行するため、プレビュー無しで選択します

## 動作確認

pwsh 7.4.6 + PSReadLine 2.3.5 で検証しました。

**バインド登録**（`<>` 付きが Command モード）:
```
<Ctrl+a>  ghq repo (fzf)      Ctrl+a  ghq repo (fzf)
<Ctrl+b>  git worktree        Ctrl+b  git worktree
<Ctrl+n>  package.json script Ctrl+n  package.json script
<Ctrl+r>  search history      Ctrl+r  search history
<Ctrl+w>  ghq repo (peco)     Ctrl+w  ghq repo (peco)
                              Ctrl+z  search history
EditMode: Vi
```

**`run-script` のパッケージマネージャ検出**（zsh / fish と一致）:
```
none            -> Running: npm run start
yarn.lock       -> Running: yarn start
pnpm-lock.yaml  -> Running: pnpm start
bun.lockb       -> Running: bun run start
```
`package.json` が無い場合のメッセージも確認済み。

**`switch-worktree`** — 実際の worktree を選ばせて該当ディレクトリに移動することを確認。

## 未検証の点

キー入力そのものは対話端末でしか試せないので、**実際に `Ctrl+W` を押したときの挙動は未確認**です。バインドの登録・各関数の動作・vi モードの設定までは確認できています。

`peco` と `fzf` が PATH にある前提です（`ws` が既に peco を使っているので新しい前提ではありません）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_