### PR TITLE
feat(windows): bind Ctrl+F to the repo picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Keybindings are mirrored too:
 | `Ctrl+A` | ghq repo (fzf) | ✓ | ✓ | ✓ |
 | `Ctrl+B` | git worktree | ✓ | ✓ | ✓ |
 | `Ctrl+N` | package.json script | ✓ | ✓ | ✓ |
-| `Ctrl+F` | tmux session (`pmux`) | ✓ | ✓ | — |
+| `Ctrl+F` | tmux session (`pmux`) | ✓ | ✓ | ✓ (repo, no tmux) |
 
-`Ctrl+F` has no PowerShell binding because there is no tmux there. `Ctrl+A` on Windows picks without the README preview, since fzf runs its preview through cmd and the Unix version leans on `find` and `bat`.
+`Ctrl+F` opens a tmux session for the picked repository on Unix. There is no tmux on Windows, so it switches to the repository instead — the same thing `Ctrl+W` does. The habit survives even though the destination is a shell rather than a session. `Ctrl+A` on Windows picks without the README preview, since fzf runs its preview through cmd and the Unix version leans on `find` and `bat`.
 
 Several of these take over a default (`Ctrl+A` beginning-of-line, `Ctrl+F` accept-autosuggestion in fish, `Ctrl+W` backward-kill-word), which is deliberate — the point is for the shells to feel the same. In fish and PowerShell they are bound in both vi modes, so they work whether or not you are in insert mode.
 

--- a/windows/keybindings.ps1
+++ b/windows/keybindings.ps1
@@ -1,8 +1,10 @@
 # NOTE: mirrors the bindkey lines in .zsh/ and fish_user_key_bindings in fish.
 # zsh is the source of truth -- see README.md.
 #
-# Ctrl+F is deliberately absent: it opens a tmux session on the Unix side, and
-# there is no tmux here.
+# Ctrl+F is the one that differs. On the Unix side it opens a tmux session for
+# the picked repository; there is no tmux here, so it switches to the repository
+# the same way Ctrl+W does. The muscle memory -- "Ctrl+F takes me to a project"
+# -- carries over even though the destination is a shell rather than a session.
 
 if (-not (Get-Module PSReadLine)) {
     Import-Module PSReadLine -ErrorAction SilentlyContinue
@@ -47,6 +49,11 @@ Set-PSReadLineKeyHandler -Chord 'Ctrl+z' -ViMode Insert -Description 'search his
 # These change directory, so redraw the prompt afterwards rather than leaving
 # the old one on screen.
 Set-Binding -Chord 'Ctrl+w' -Description 'ghq repo (peco)' -Action {
+    ws
+    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+}
+# No tmux here, so this lands in the repository instead of a session.
+Set-Binding -Chord 'Ctrl+f' -Description 'ghq repo (peco)' -Action {
     ws
     [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
 }


### PR DESCRIPTION
#289 で `Ctrl+F` は Windows 側だけ未割り当てにしていました。Unix では `pmux` が tmux セッションを作るもので、Windows に tmux が無いためです。

代わりに **`ws` を割り当て**ます（`Ctrl+W` と同じ）。「`Ctrl+F` を押すとプロジェクトに移動する」という指の記憶は、移動先がセッションではなくシェルになっても成り立つためです。

## 変更後の対応表

| キー | 動作 | zsh | fish | PowerShell |
| --- | --- | --- | --- | --- |
| `Ctrl+R` / `Ctrl+Z` | 履歴検索 | ✓ | ✓ | ✓ |
| `Ctrl+W` | ghq リポジトリ（peco） | ✓ | ✓ | ✓ |
| `Ctrl+A` | ghq リポジトリ（fzf） | ✓ | ✓ | ✓ |
| `Ctrl+B` | git worktree | ✓ | ✓ | ✓ |
| `Ctrl+N` | package.json スクリプト | ✓ | ✓ | ✓ |
| `Ctrl+F` | tmux セッション（`pmux`） | ✓ | ✓ | **✓（リポジトリへ移動）** |

これで **6 キーすべてが 3 シェルで埋まりました**。

## 動作確認

両 vi モードに登録されることを確認しました（`<>` 付きが Command モード）。

```
  <Ctrl+f>     ghq repo (peco)
  Ctrl+f       ghq repo (peco)
```

全 `.ps1` パース OK、bats 48 pass。

## 補足

`Ctrl+F` は PSReadLine の既定では `ForwardChar` です。`Ctrl+A`（行頭）や `Ctrl+W`（単語削除）と同じく、統一のために既定を上書きする形になります。カーソルを 1 文字進めるのは vi モードなら `l` でできます。

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_