### PR TITLE
feat(komorebi): force-manage the Claude desktop window

### DIFF
--- a/.config/komorebi/.komorebi.json
+++ b/.config/komorebi/.komorebi.json
@@ -26,6 +26,13 @@
   "animation": {
     "enabled": false
   },
+  "manage_rules": [
+    {
+      "kind": "Exe",
+      "id": "claude.exe",
+      "matching_strategy": "Equals"
+    }
+  ],
   "monitors": [
     {
       "workspaces": [


### PR DESCRIPTION
`claude.exe` が自動ではタイル管理されないため、`manage_rules` を追加します。

```json
"manage_rules": [
  {
    "kind": "Exe",
    "id": "claude.exe",
    "matching_strategy": "Equals"
  }
]
```

`manage_rules` はこの設定ファイルに初めて追加されるキーです。`animation` と `monitors` の間、他のトップレベル設定と同じ並びに置きました。

## 動作確認

設定が pin している **komorebi v0.1.31 のスキーマで検証**しました。

```
manage_rules あり: True  (Individual window force-manage rules)
✅ komorebi v0.1.31 のスキーマ検証を通過
```

JSON としてのパースも確認済みです。

## 反映

`.config/komorebi/.komorebi.json` は `setup-komorebi.ps1` が `%USERPROFILE%\.config\komorebi.json` に symlink しているので、`git pull` すれば実体に反映されます。komorebi 側の再読み込みは必要です。

```powershell
komorebic reload-configuration
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_