### PR TITLE
feat(komorebi): force-manage the UAD Console window

### DIFF
--- a/.config/komorebi/.komorebi.json
+++ b/.config/komorebi/.komorebi.json
@@ -31,6 +31,11 @@
       "kind": "Exe",
       "id": "claude.exe",
       "matching_strategy": "Equals"
+    },
+    {
+      "kind": "Exe",
+      "id": "UAD Console.exe",
+      "matching_strategy": "Equals"
     }
   ],
   "monitors": [


### PR DESCRIPTION
Adds `UAD Console.exe` to `manage_rules` in `.config/komorebi/.komorebi.json`, alongside the `claude.exe` entry from #293.

```json
{
  "kind": "Exe",
  "id": "UAD Console.exe",
  "matching_strategy": "Equals"
}
```

`matching_strategy: "Equals"` is an exact match on the executable name, so a wrong name makes the rule a silent no-op. This one is the name confirmed on the machine that runs komorebi.

Validated: the file parses as JSON and still validates against the komorebi v0.1.31 schema it declares in `$schema`.

After pulling, komorebi needs `komorebic reload-configuration` to pick this up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_