### PR TITLE
fix(komorebi): keep the UAD manage rule off plugin windows

### DIFF
--- a/.config/komorebi/.komorebi.json
+++ b/.config/komorebi/.komorebi.json
@@ -32,11 +32,18 @@
       "id": "claude.exe",
       "matching_strategy": "Equals"
     },
-    {
-      "kind": "Exe",
-      "id": "UAD Console.exe",
-      "matching_strategy": "Equals"
-    }
+    [
+      {
+        "kind": "Exe",
+        "id": "UAD Console.exe",
+        "matching_strategy": "Equals"
+      },
+      {
+        "kind": "Title",
+        "id": "UAD Console",
+        "matching_strategy": "StartsWith"
+      }
+    ]
   ],
   "monitors": [
     {

--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ The window manager is [komorebi](https://github.com/LGUG2Z/komorebi) with
 `powershell/komorebi-start.ps1` and `komorebi-stop.ps1` (plus `.bat` wrappers)
 drive it.
 
+`manage_rules` in `.config/komorebi/.komorebi.json` force-manages windows
+komorebi would otherwise leave floating. Scope those rules as tightly as the
+application allows: a bare `Exe` rule matches *every* window of that process,
+so an app whose plugin or dialog windows are separate top-level windows would
+get all of them tiled too. A nested array is a composite rule — every entry in
+it has to match — which is how the UAD Console entry keeps to the main window.
+Note that `manage_rules` wins over `ignore_rules`, so a too-broad force-manage
+rule cannot be walked back with an ignore rule; narrow the rule itself.
+
+`komorebic visible-windows` prints the exe, title and class of what is on
+screen, which is where the ids in those rules come from. Matching is exact for
+`Equals`, so a wrong id is a silent no-op. Changes need
+`komorebic reload-configuration`.
+
 There is no `Brewfile` equivalent: those tools, plus whatever
 `windows/path.ps1` expects (scoop, direnv, poetry), have to be installed by
 hand.


### PR DESCRIPTION
Follow-up to #294. The `Exe`-only rule added there matches **every** top-level window of `UAD Console.exe`, so the plugin editor windows would have been force-tiled along with the Console — the opposite of what you want from a plugin UI.

An `ignore_rules` entry cannot undo that. In `window_is_eligible` (komorebi v0.1.31, `komorebi/src/window.rs`):

```rust
if should_ignore && !managed_override {
    return false;
}
```

a force-manage match beats an ignore match, so the manage rule itself has to be narrower.

`manage_rules` entries can be a nested array — a composite rule, where `should_act` requires **all** entries to match:

```json
[
  { "kind": "Exe",   "id": "UAD Console.exe", "matching_strategy": "Equals" },
  { "kind": "Title", "id": "UAD Console",     "matching_strategy": "StartsWith" }
]
```

So only the window whose title starts with `UAD Console` gets force-managed; plugin windows keep the floating behaviour they have today.

**Assumption to check on the machine:** that the Console's own window title starts with `UAD Console`. Matching is exact, so if it doesn't, the rule simply stops matching and every UAD window floats — i.e. the pre-#294 behaviour, never tiled plugins. `komorebic visible-windows` shows the real title with the Console open; the `id` is a one-line fix if it differs.

Also adds a README paragraph on scoping these rules, since neither the composite syntax nor the manage-beats-ignore precedence is visible from the config.

Validated: the file parses as JSON and still validates against the komorebi v0.1.31 schema in `$schema` (composite entries included).

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_