### PR TITLE
fix(komorebi): leave the UAD plugin windows unmanaged

### DIFF
--- a/.config/komorebi/.komorebi.json
+++ b/.config/komorebi/.komorebi.json
@@ -45,6 +45,20 @@
       }
     ]
   ],
+  "ignore_rules": [
+    [
+      {
+        "kind": "Exe",
+        "id": "UAD Console.exe",
+        "matching_strategy": "Equals"
+      },
+      {
+        "kind": "Title",
+        "id": "UAD Console",
+        "matching_strategy": "DoesNotStartWith"
+      }
+    ]
+  ],
   "monitors": [
     {
       "workspaces": [

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ it has to match — which is how the UAD Console entry keeps to the main window.
 Note that `manage_rules` wins over `ignore_rules`, so a too-broad force-manage
 rule cannot be walked back with an ignore rule; narrow the rule itself.
 
+`ignore_rules` is for the other direction: windows komorebi *would* tile on its
+own but shouldn't. The UAD entry is the negative of its manage rule — every
+window of that process whose title is not the Console's — so the plugin editor
+windows stay floating however they are titled. A window already on screen when
+the config is reloaded keeps its current state; reopen it to re-evaluate.
+
 `komorebic visible-windows` prints the exe, title and class of what is on
 screen, which is where the ids in those rules come from. Matching is exact for
 `Equals`, so a wrong id is a silent no-op. Changes need


### PR DESCRIPTION
Follow-up to #295. Narrowing the manage rule was necessary but not sufficient: the plugin editor windows are ordinary top-level windows with `WS_CAPTION` + `WS_EX_WINDOWEDGE`, so komorebi tiles them through its own eligibility check in `window_is_eligible` — no rule has to point at them at all.

That is the case `ignore_rules` exists for, and it works here because the manage rule no longer matches plugin windows (a `managed_override` would have beaten the ignore).

```json
"ignore_rules": [
  [
    { "kind": "Exe",   "id": "UAD Console.exe", "matching_strategy": "Equals" },
    { "kind": "Title", "id": "UAD Console",     "matching_strategy": "DoesNotStartWith" }
  ]
]
```

It is the exact negative of the manage rule — every window of that process that is not the Console — so it holds whatever the plugin windows happen to be titled, with no per-plugin entries to maintain.

**The Console cannot be caught by this.** It is being tiled today, which means the manage rule's `Title StartsWith "UAD Console"` matched, so the `DoesNotStartWith` arm is false for it.

Verified by porting `should_act` / `should_act_individual` and the `if should_ignore && !managed_override` precedence to a script and running the config's real rules against sample windows:

```
console          manage=True  ignore=False -> force-managed (tiled)
console+ver      manage=True  ignore=False -> force-managed (tiled)
plugin LA-2A     manage=False ignore=True  -> ignored (floats)
plugin 1176      manage=False ignore=True  -> ignored (floats)
other app        manage=False ignore=False -> default eligibility
```

Also validates against the komorebi v0.1.31 schema in `$schema`.

One caveat worth knowing after `komorebic reload-configuration`: a plugin window that is already on screen keeps its current managed state — close and reopen it to see the rule take effect. Noted in the README along with the ignore-rule direction.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_