### PR TITLE
feat(claude): add a tailscale-serve skill and install skills from make claude

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `make` or `make dotfiles` — symlink all dotfiles (`.??*` except `.git`, `.gitignore`, etc.) into `$HOME`
 - `make config` — symlink `.config/*` entries into `$HOME/.config/`
-- `make claude` — symlink `configs/claude/settings.json` to `~/.claude/settings.json` (Claude Code hooks etc.; machine-local state like `feedbackSurveyState` is intentionally not committed)
+- `make claude` — symlink `configs/claude/settings.json` to `~/.claude/settings.json` (Claude Code hooks etc.; machine-local state like `feedbackSurveyState` is intentionally not committed), and each `configs/claude/skills/*` directory into `~/.claude/skills/`. Skills are linked individually because `~/.claude/skills` is shared with skills installed from elsewhere
 - `make vscodeExtensions` — sync VSCode extensions via `configs/.vscode/vscodeSync.sh`
 - `make list` — show which dotfiles will be symlinked
 - `make help` — print all make targets
@@ -28,6 +28,7 @@ This is a cross-platform dotfiles repo (macOS, Linux/WSL, Windows). The core mec
 - `.config/nvim/` — Neovim config using LazyVim framework (`config/lazy.lua` bootstraps lazy.nvim, plugins in `lua/plugins/`)
 - `.config/fish/` — Fish shell config (experimental, best-effort). zsh is the source of truth for aliases and functions; fish carries only a subset. An alias defined in both shells must behave identically — add it to the matching `.zsh/*.zsh` module first
 - `configs/.vscode/` — VSCode settings, keybindings, and extension sync script
+- `configs/claude/skills/<name>/SKILL.md` — Claude Code skills shared across machines. The frontmatter `name` must equal the directory name, and `description` is the trigger text Claude Code matches on; `test/makefile.bats` enforces both
 - `.scripts/` — custom CLI tools added to PATH (`duck`, `google`, `pmux`, `git-worktree-pull`)
 - `powershell/` — komorebi start/stop scripts, and `DotfilesSetup.ps1` (the symlink helper the `setup-*.ps1` scripts share). Kept out of `windows/`, which `bootstrap.ps1` sources into every shell
 - `windows/*.ps1` — PowerShell profile parts, sourced in filename order by the `$PROFILE` loader `bootstrap.ps1` writes. `keybindings.ps1` mirrors the zsh keybinds via PSReadLine; `functions.ps1` holds what they call

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ IGNORE	:= .DS_Store .git .gitmodules .gitignore .github .config .devcontainer .v
 TARGET	:= $(filter-out $(IGNORE), $(DOTFILES))
 VSCODE_SCRIPT_PATH := $(abspath configs/.vscode)
 CONFIG_PATH := $(wildcard .config/??*)
+# Linked one skill at a time rather than as a whole directory: ~/.claude/skills
+# is shared with skills that came from elsewhere, and replacing it with a link
+# to this repository would hide them.
+CLAUDE_SKILL_PATH := $(wildcard configs/claude/skills/??*)
 .DEFAULT_GOAL	:= dotfiles
 
 .PHONY: list dotfiles config claude unlink brew bootstrap vscodeExtensions help
@@ -38,11 +42,12 @@ config: # Create symlinks of .config at home directory
 	@$(foreach val, $(CONFIG_PATH), $(call link,$(abspath $(val)),$(HOME)/$(val)))
 	@echo '------------------------'
 
-claude: # Create symlink of Claude Code settings.json in ~/.claude
-	@echo 'claude - Setting symlink of Claude Code settings.json in ~/.claude'
+claude: # Create symlinks of Claude Code settings.json and skills in ~/.claude
+	@echo 'claude - Setting symlinks of Claude Code settings.json and skills in ~/.claude'
 	@echo '------------------------'
-	@mkdir -p $(HOME)/.claude
+	@mkdir -p $(HOME)/.claude/skills
 	@ln -sfnv $(abspath configs/claude/settings.json) $(HOME)/.claude/settings.json
+	@$(foreach val, $(CLAUDE_SKILL_PATH), $(call link,$(abspath $(val)),$(HOME)/.claude/skills/$(notdir $(val))))
 	@echo '------------------------'
 
 unlink: # Remove dotfile symlinks from home directory

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For just the symlinks:
 ```
 make            # symlink dotfiles into $HOME
 make config     # symlink .config entries
+make claude     # symlink Claude Code settings and skills into ~/.claude
 ```
 
 ## Windows
@@ -198,6 +199,23 @@ That is the whole setup — everything else fish needs is either already in the 
 | `killport` | Kill the processes listening on a given port (`killport 8080`). |
 | `duck` / `google` | Search DuckDuckGo / Google from the terminal via lynx. |
 | `urlencode` | URL-encode arguments or stdin; used by `duck` and `google`. |
+
+## Claude Code
+
+`make claude` links `configs/claude/` into `~/.claude`: `settings.json`, plus
+every directory under `configs/claude/skills/` into `~/.claude/skills/`. The
+skills are linked one at a time rather than as a whole directory, so skills
+installed from anywhere else stay where they are. A skill directory that already
+exists in `~/.claude/skills` as a real directory is reported and skipped rather
+than overwritten.
+
+| Skill | Description |
+| --- | --- |
+| `tailscale-serve` | Expose a dev server on the machine you are SSH'd into to the rest of the tailnet with `tailscale serve`, so a browser on the machine you are sitting at can reach it. Pairs with `tssh`. |
+
+A skill is a `SKILL.md` with YAML frontmatter; the `name` has to match its
+directory and the `description` is what Claude Code matches against to decide
+when to load it. `test/makefile.bats` checks both.
 
 ## Environment Variables
 

--- a/configs/claude/skills/tailscale-serve/SKILL.md
+++ b/configs/claude/skills/tailscale-serve/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: tailscale-serve
+description: Expose a locally-running dev server to the rest of the tailnet with Tailscale Serve, so a browser on another machine can reach it. Detects what is listening, serves it over HTTPS, reports the URL, and tears it down again. Use when the user says "tailscale serve", "このサービスを他のマシンから見たい", "SSH先のlocalhostにアクセスしたい", "serve this port", or similar.
+---
+
+# tailscale-serve
+
+Dev servers bind to `127.0.0.1`, so a server started over SSH is invisible from
+the machine you are sitting at. `tailscale serve` proxies from the tailnet to
+that same loopback address — **the dev server does not have to be restarted or
+rebound to `0.0.0.0`**, which is the whole appeal.
+
+Scope: **tailnet only**. Publishing to the internet is `tailscale funnel`, which
+this skill does not run — see Constraints.
+
+## Steps
+
+1. **Find what to serve.** If the user named a port, use it. Otherwise list what
+   is listening:
+
+   ```bash
+   lsof -nP -iTCP -sTCP:LISTEN    # macOS
+   ss -ltnp                       # Linux
+   ```
+
+   Report only the plausible dev ports (3000/4321/5173/8000/8080 …) with their
+   process names, not the whole table. If exactly one dev server is up, say
+   which one you picked instead of asking.
+
+2. **Check Tailscale is usable.**
+
+   ```bash
+   tailscale status
+   ```
+
+   If the CLI is missing or the node is logged out, say so and stop — nothing
+   else here works.
+
+3. **Serve it.**
+
+   ```bash
+   tailscale serve --bg 3000
+   ```
+
+   `--bg` keeps it up after the command returns; without it the command runs in
+   the foreground and the mapping dies with Ctrl+C. Background is what you want
+   for a session you will come back to.
+
+   The target can also be `localhost:3000`, a full URL with a path
+   (`http://localhost:3000/foo`), `https+insecure://localhost:8443` for a dev
+   server with a self-signed cert, or `unix:/var/run/app.sock`.
+
+4. **Report the URL — it is in the output already.** The command prints it,
+   along with the exact teardown command:
+
+   ```
+   Available within your tailnet:
+
+   https://mbp.tailnet-name.ts.net/
+   |-- proxy http://127.0.0.1:3000
+
+   Serve started and running in the background.
+   To disable the proxy, run: tailscale serve --https=443 off
+   ```
+
+   Give the user the full URL, not instructions for assembling one. For a
+   mapping made earlier, `tailscale serve status` lists them:
+
+   ```
+   https://mbp.tailnet-name.ts.net (tailnet only)
+   |-- /  proxy http://127.0.0.1:3000
+   ```
+
+   It prints `No serve config` when nothing is served. `--json` is available on
+   `status` if you would rather parse than scrape.
+
+5. **Pass on the teardown line** in the same message:
+
+   ```bash
+   tailscale serve --https=443 off    # this one mapping
+   tailscale serve reset              # every mapping on this machine
+   ```
+
+## When it does not work
+
+- **The tailnet does not have HTTPS Certificates enabled.** Serve needs them.
+  The CLI does not just fail: it prints an admin-console URL and then **blocks,
+  waiting for someone to flip the setting**, so a non-interactive run will hang
+  there. If you see that prompt, stop the command, pass the URL to the user, and
+  let them enable it before retrying — do not sit on a blocked command. The
+  first request after enabling can be slow while the cert is issued.
+
+- **The page loads but the dev server rejects the request.** Vite checks the
+  `Host` header, which now arrives as `<machine>.<tailnet>.ts.net`:
+
+  ```
+  Blocked request. This host ("mbp.tailnet-name.ts.net") is not allowed.
+  To allow this host, add "mbp.tailnet-name.ts.net" to `server.allowedHosts` in vite.config.js.
+  ```
+
+  A leading dot matches the domain and all of its subdomains, so one entry
+  covers every machine in the tailnet and survives a rename:
+
+  ```js
+  // vite.config.js
+  export default {
+    server: { allowedHosts: ['.ts.net'] },
+  }
+  ```
+
+  Use `preview.allowedHosts` for `vite preview`. Other frameworks with a host
+  check (webpack-dev-server's `allowedHosts`, Next.js `allowedDevOrigins`) need
+  the equivalent entry.
+
+- **You need it working right now and HTTPS certs are not an option.** Forward
+  from the client side instead — it needs nothing on the remote:
+
+  ```bash
+  ssh -L 3000:127.0.0.1:3000 <host>
+  ```
+
+  Then open `http://localhost:3000` locally. This is the fallback, not the
+  default: it dies with the SSH session and serves only that one client.
+
+- **Binding to `0.0.0.0` and using the raw Tailscale IP** (`http://100.x.y.z:3000`)
+  also works, but means restarting the dev server with a different bind address.
+  Prefer Serve.
+
+- **An older Tailscale rejects the argument form above.** The positional target
+  and `--bg` come from the current serve CLI; older releases used
+
+  ```bash
+  tailscale serve https:443 / http://127.0.0.1:3000
+  ```
+
+  Check `tailscale serve --help` rather than guessing which form applies.
+
+## Constraints
+
+- **Never run `tailscale funnel`** unless the user asks for public exposure in
+  that turn. Funnel publishes to the open internet, and an unauthenticated dev
+  server is exactly what should not be published. If they do ask, say plainly
+  what it exposes before running it.
+- Do not restart or reconfigure the user's dev server to make Serve work. Serve
+  proxies to loopback; if something fails, fix the Serve side or report it.
+- `tailscale serve reset` clears **all** mappings on the machine, including ones
+  this skill did not create. Prefer the targeted `off` form unless the user asks
+  to clear everything.
+- Read-only on the repository: this skill runs commands, it does not edit files
+  or commit. The one exception is the `allowedHosts` fix above, which is an edit
+  to the user's project — propose it, do not slip it in.

--- a/test/makefile.bats
+++ b/test/makefile.bats
@@ -122,6 +122,66 @@ assert_links_to() {
   assert_links_to "$FAKE_HOME/.claude/settings.json" "$REPO/configs/claude/settings.json"
 }
 
+@test "make claude symlinks each skill into ~/.claude/skills" {
+  run make -C "$REPO" claude HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.claude/skills/tailscale-serve" \
+    "$REPO/configs/claude/skills/tailscale-serve"
+  [ -f "$FAKE_HOME/.claude/skills/tailscale-serve/SKILL.md" ]
+}
+
+@test "make claude leaves skills it did not install alone" {
+  # ~/.claude/skills is shared, so linking the directory as a whole would hide
+  # whatever else is in it. Link the skills one at a time instead.
+  mkdir -p "$FAKE_HOME/.claude/skills/someone-elses"
+  touch "$FAKE_HOME/.claude/skills/someone-elses/SKILL.md"
+
+  run make -C "$REPO" claude HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  [ -f "$FAKE_HOME/.claude/skills/someone-elses/SKILL.md" ]
+  assert_links_to "$FAKE_HOME/.claude/skills/tailscale-serve" \
+    "$REPO/configs/claude/skills/tailscale-serve"
+}
+
+@test "make claude does not nest the link inside an existing real skill directory" {
+  mkdir -p "$FAKE_HOME/.claude/skills/tailscale-serve"
+  echo "mine" >"$FAKE_HOME/.claude/skills/tailscale-serve/SKILL.md"
+
+  run make -C "$REPO" claude HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  [ ! -e "$FAKE_HOME/.claude/skills/tailscale-serve/tailscale-serve" ]
+  [ "$(cat "$FAKE_HOME/.claude/skills/tailscale-serve/SKILL.md")" = "mine" ]
+}
+
+@test "make claude is idempotent" {
+  make -C "$REPO" claude HOME="$FAKE_HOME"
+  run make -C "$REPO" claude HOME="$FAKE_HOME"
+  [ "$status" -eq 0 ]
+  assert_links_to "$FAKE_HOME/.claude/skills/tailscale-serve" \
+    "$REPO/configs/claude/skills/tailscale-serve"
+  [ ! -e "$FAKE_HOME/.claude/skills/tailscale-serve/tailscale-serve" ]
+}
+
+# --- skills ------------------------------------------------------------------
+
+@test "every skill has SKILL.md with a name and description in its frontmatter" {
+  # Claude Code reads the frontmatter to decide when to load a skill, so a
+  # skill missing either field is installed but never triggers.
+  shopt -s nullglob
+  local found=0
+  for skill in "$REPO"/configs/claude/skills/*/; do
+    found=$((found + 1))
+    [ -f "$skill/SKILL.md" ]
+    run head -1 "$skill/SKILL.md"
+    [ "$output" = "---" ]
+    grep -q '^name: ' "$skill/SKILL.md"
+    grep -q '^description: ' "$skill/SKILL.md"
+    # The directory name is the skill name; a mismatch is confusing at best.
+    grep -q "^name: $(basename "$skill")\$" "$skill/SKILL.md"
+  done
+  [ "$found" -gt 0 ]
+}
+
 # --- make unlink -------------------------------------------------------------
 
 @test "make unlink removes the symlinks it created" {


### PR DESCRIPTION
Adds `configs/claude/skills/tailscale-serve/SKILL.md` — how to reach a dev server running on the machine you SSH'd into, from the browser on the machine you are sitting at — and the plumbing to install skills.

## Where it lives

This is the repo's first skill, so `make claude` grows a second job: it links `configs/claude/skills/*` into `~/.claude/skills/`.

Linked **one skill at a time**, not as a whole directory. `~/.claude/skills` is shared with skills installed from elsewhere, and pointing it at this repo would hide them. A skill directory that already exists there for real is reported and skipped, using the same `link` macro as the other targets.

## Verification

The draft was written untested, so I checked each item rather than shipping guesses.

**Checked against sources** (`cmd/tailscale/cli/serve_v2.go`, `serve_legacy.go` in tailscale/tailscale):

- `tailscale serve --bg 3000` is the current form; the positional target also accepts `localhost:3000`, a full URL with a path, `https+insecure://`, and `unix:` sockets
- the command **already prints the URL** and the exact teardown line, so the skill no longer tells the agent to run `tailscale serve status` just to assemble one:
  ```
  Available within your tailnet:

  https://mbp.tailnet-name.ts.net/
  |-- proxy http://127.0.0.1:3000

  Serve started and running in the background.
  To disable the proxy, run: tailscale serve --https=443 off
  ```
- `serve status` output shape (`https://host (tailnet only)` + handler tree, `No serve config` when empty, `--json` available) is in the skill for mappings made earlier
- **the HTTPS-certificates case is worse than the draft assumed.** `enableFeatureInteractive` does not fail — it prints an admin-console URL and then *blocks on the IPN bus waiting for someone to enable the setting*. A non-interactive agent run would hang there. The skill now says to stop the command and hand the URL to the user

**Reproduced locally** (Vite 8.2.1, real dev server, `Host` header set by hand):

```
mbp.tailnet-name.ts.net        -> 403   Blocked request. This host (...) is not allowed.
```

then with `server: { allowedHosts: ['.ts.net'] }`:

```
mbp.tailnet-name.ts.net        -> 200
other.tail1234.ts.net          -> 200
evil.example.com               -> 403
```

A leading-dot entry matches the domain and all subdomains (confirmed in `host-validation-middleware`), so one line covers every machine in the tailnet and survives a rename — that is what the skill recommends, instead of pasting one hostname.

**Could not be checked here** — this container has no Tailscale and no tailnet:

- whether the installed Tailscale on the Mac accepts the current argument form (the skill keeps the old-CLI fallback, phrased as "if it is rejected", with no version number asserted since I could not pin the boundary)
- whether the tailnet has HTTPS Certificates enabled

Both show up the first time the skill runs; neither changes the file.

## Tests

`test/makefile.bats` grows 5 tests: skills get linked, other people's skills survive, an existing real directory is not buried, the target is idempotent, and every `SKILL.md` has frontmatter whose `name` matches its directory (a mismatch installs fine but never triggers). All 21 pass.

Each new test was checked by breaking the thing it covers:

| Break | Result |
| --- | --- |
| drop the skill-linking line | tests 13, 14, 16 fail |
| link `skills/` as one directory | tests 13, 14, 16 fail |
| rename the skill in frontmatter | test 17 fails |

Full suite green: `makefile` 21, `scripts` 23, `aliases` 11, `fish-config` 12, `prompt` 10.

README gains a Claude Code section (with the skill table) and `make claude` in the quick-start list; CLAUDE.md notes the frontmatter contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_