### PR TITLE
feat: copy yanks over SSH to the client clipboard via OSC 52

### DIFF
--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -1,1 +1,32 @@
 vim.g.snacks_animate = false
+
+-- SSH 越しのときは yank を OSC 52 で接続元のクリップボードに送る。
+-- Neovim 0.10+ の自動検出は「pbcopy/xclip 等が無い」かつ「tmux を挟まない」
+-- ときしか効かないので (:h clipboard-osc52)、SSH セッションでは明示する。
+-- ローカル起動では何もしない (既定の pbcopy/wl-copy 等のまま)。
+if vim.env.SSH_TTY or vim.env.SSH_CONNECTION then
+  local osc52 = require("vim.ui.clipboard.osc52")
+  -- OSC 52 での読み出しは多くの端末が拒否し、組み込みの paste は応答を最大 10 秒
+  -- 待ってしまう。端末には問い合わせず、最後に送った内容を返すだけにする。
+  local last = { ["+"] = { {}, "v" }, ["*"] = { {}, "v" } }
+  local function copy(reg)
+    local send = osc52.copy(reg)
+    return function(lines, regtype)
+      last[reg] = { lines, regtype }
+      send(lines, regtype)
+    end
+  end
+  local function paste(reg)
+    return function()
+      return last[reg]
+    end
+  end
+  vim.g.clipboard = {
+    name = "OSC 52 (ssh)",
+    copy = { ["+"] = copy("+"), ["*"] = copy("*") },
+    paste = { ["+"] = paste("+"), ["*"] = paste("*") },
+  }
+  -- LazyVim は SSH 中は clipboard を空にする (素の yy がプロバイダを通らず、
+  -- OSC 52 が一度も出ない)。ここでは明示プロバイダがあるので同期を戻す。
+  vim.opt.clipboard = "unnamedplus"
+end

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -31,6 +31,11 @@ set-option -g status-position top
 # Claudeマークの経過時間表示 (tmux-claude-elapsed) を進めるために定期再描画する
 set -g status-interval 15
 set-option default-terminal "screen-256color"
+# SSH 先の vim/nvim が出す OSC 52 を外側の端末まで中継する (クリップボード連携)。
+# これが無いと tmux がエスケープを握り潰して、接続元のクリップボードに届かない
+set -g set-clipboard on
+set -g allow-passthrough on
+set -as terminal-features ',*:clipboard'
 # Plugins (TPM は未導入なら自動で clone される / <prefix> + I で追加インストール)
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'catppuccin/tmux'

--- a/.vim/vimrc
+++ b/.vim/vimrc
@@ -64,3 +64,36 @@ set shell=/bin/zsh
 
 
 cnoreabbrev S s
+
+" SSH 越しのときは yank を OSC 52 で接続元のクリップボードに送る。
+" 素の Vim は OSC 52 を出さないので TextYankPost で自前で書き出す
+" (Vim 8.0.1394+)。ローカル起動では何もしない。
+" Neovim はこの vimrc を init.lua から source しているが、そちらは
+" lua/config/options.lua の clipboard プロバイダで対応済みなので除外する
+" (nvim には echoraw() が無く、0.11 以降はサーバー側に制御端末も無い)。
+if !has('nvim') && (!empty($SSH_TTY) || !empty($SSH_CONNECTION))
+  function! s:OscYank() abort
+    if v:event.operator !=# 'y' | return | endif
+    let l:text = join(v:event.regcontents, "\n")
+    if v:event.regtype ==# 'V' | let l:text .= "\n" | endif
+    let l:b64 = substitute(system('base64', l:text), '\n', '', 'g')
+    let l:seq = "\e]52;c;" . l:b64 . "\x07"
+    " tmux は set-clipboard on なら素の OSC 52 を外側の端末へ中継する。
+    " echoraw() (Vim 8.2.2044+) は Vim が使っている端末にそのまま書く。
+    " /dev/tty は制御端末が無い起動だと E482 になるので最後の手段にする
+    if exists('*echoraw')
+      call echoraw(l:seq)
+    else
+      " filewritable() が真でも制御端末が無いと open は ENXIO で失敗する。
+      " その場合はクリップボードに届かないだけなので黙って諦める
+      try
+        call writefile([l:seq], '/dev/tty', 'b')
+      catch /^Vim\%((\a\+)\)\=:E482/
+      endtry
+    endif
+  endfunction
+  augroup OscYank
+    autocmd!
+    autocmd TextYankPost * call s:OscYank()
+  augroup END
+endif

--- a/README.md
+++ b/README.md
@@ -200,6 +200,46 @@ That is the whole setup — everything else fish needs is either already in the 
 | `duck` / `google` | Search DuckDuckGo / Google from the terminal via lynx. |
 | `urlencode` | URL-encode arguments or stdin; used by `duck` and `google`. |
 
+## Clipboard over SSH
+
+`y` in vim/nvim on an SSH target can only reach the client's clipboard through
+the terminal, via the OSC 52 escape sequence. When `$SSH_TTY`/`$SSH_CONNECTION`
+is set:
+
+- **Neovim** (`.config/nvim/lua/config/options.lua`) forces the OSC 52
+  clipboard provider. The built-in auto-detection is *not* enough: it only kicks
+  in when no `pbcopy`/`xclip`/`wl-copy` exists on the server and it is inhibited
+  by tmux (`:h clipboard-osc52`), so a Mac target would silently copy to its own
+  clipboard. Paste (`"+p`, `P`) returns the last yank instead of asking the
+  terminal, because most terminals refuse clipboard reads and nvim would wait
+  up to 10 s.
+- **Vim** (`.vim/vimrc`) writes OSC 52 on `TextYankPost` with a few lines of
+  vimscript; no plugin needed.
+- **tmux** (`.tmux.conf`) has `set-clipboard on` and `allow-passthrough on` so
+  the sequence is relayed to the outer terminal instead of swallowed.
+- Locally (no SSH variables) nothing changes.
+
+Terminals: WezTerm, kitty, Ghostty, Windows Terminal and Alacritty accept
+OSC 52 writes by default. **iTerm2 does not** — enable
+*Settings → General → Selection → "Applications in terminal may access
+clipboard"* (GUI only, not in dotfiles).
+
+To check the path without an editor, run this on the server and paste on the
+client (inside tmux, `tmux show-buffer` shows whether tmux relayed it):
+
+```sh
+printf '\033]52;c;%s\a' "$(printf hello | base64)"
+```
+
+Note that a tmux server started locally and attached later over SSH does not
+have the SSH variables in already-open shells; open a new window or
+`tmux set-environment`.
+
+Payload limit: tmux does not truncate (checked with 500 lines / 20 KB), but some
+terminals cap a single OSC 52 at 100 000 bytes of base64 (~74 KB of text, the
+xterm default). A yank above that is dropped silently. Workaround for anything
+bigger: write it to a file and `scp`, or yank in chunks.
+
 ## Claude Code
 
 `make claude` links `configs/claude/` into `~/.claude`: `settings.json`, plus


### PR DESCRIPTION
## Summary
`y` in vim/nvim on a Tailscale SSH target now lands in the client machine's clipboard, via OSC 52. Only active when `$SSH_TTY`/`$SSH_CONNECTION` is set; local sessions are unchanged.

- **nvim** (`lua/config/options.lua`): explicit OSC 52 clipboard provider + `clipboard=unnamedplus`. Needed because nvim's auto OSC 52 only applies when no `pbcopy`/`xclip` exists on the server and is inhibited by tmux (`:h clipboard-osc52`), and LazyVim blanks `clipboard` under SSH so `yy` never reached a provider. Paste returns the last yank instead of querying the terminal (most refuse reads; nvim would block up to 10 s).
- **vim** (`.vim/vimrc`): OSC 52 on `TextYankPost` via `echoraw()`, no plugin. Guarded with `!has('nvim')` since `init.lua` sources this file.
- **tmux**: `set-clipboard on`, `allow-passthrough on`, `terminal-features ',*:clipboard'`.
- **README**: "Clipboard over SSH" section incl. a one-line shell check, the iTerm2 GUI toggle and the ~100 KB payload cap.

## Test plan
- [x] `yy` in nvim over SSH (MacBook → Mac mini, inside tmux) pastes on the MacBook
- [x] 500-line / 20 KB payload relayed intact through tmux
- [x] Local nvim: `vim.g.clipboard` stays nil, `clipboard=unnamedplus` via pbcopy as before
- [x] Vim 9.1 in a pty emits the sequence with no errors; no-tty case is silent
- [x] `bats test`, `zsh -n .zshrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
