### PR TITLE
feat(claude): tailscale-serve skill — verify the URL and handle multi-service apps

### DIFF
--- a/configs/claude/skills/tailscale-serve/SKILL.md
+++ b/configs/claude/skills/tailscale-serve/SKILL.md
@@ -46,11 +46,28 @@ this skill does not run — see Constraints.
    the foreground and the mapping dies with Ctrl+C. Background is what you want
    for a session you will come back to.
 
+   Run it with a short timeout (~30s). On success it returns in a couple of
+   seconds; anything longer means it is sitting on an enablement prompt (see
+   "When it does not work") and waiting the full default timeout teaches you
+   nothing.
+
    The target can also be `localhost:3000`, a full URL with a path
    (`http://localhost:3000/foo`), `https+insecure://localhost:8443` for a dev
    server with a self-signed cert, or `unix:/var/run/app.sock`.
 
-4. **Report the URL — it is in the output already.** The command prints it,
+4. **Verify it before reporting it.** One curl catches both proxy problems and
+   the Vite host-check block, and is cheaper than letting the user find them in
+   a browser:
+
+   ```bash
+   curl -sS -o /dev/null -w "%{http_code}" -m 15 https://mbp.tailnet-name.ts.net/
+   ```
+
+   Expect 200. (The very first request may be slow while the TLS cert is
+   issued.) A 403-ish body mentioning "Blocked request" is the host check —
+   see below.
+
+5. **Report the URL — it is in the output already.** The command prints it,
    along with the exact teardown command:
 
    ```
@@ -74,12 +91,68 @@ this skill does not run — see Constraints.
    It prints `No serve config` when nothing is served. `--json` is available on
    `status` if you would rather parse than scrape.
 
-5. **Pass on the teardown line** in the same message:
+6. **Pass on the teardown line** in the same message:
 
    ```bash
    tailscale serve --https=443 off    # this one mapping
    tailscale serve reset              # every mapping on this machine
    ```
+
+## Multi-service apps: one port is rarely enough
+
+Serving the frontend is the finish line only for a static page. An SPA's
+JavaScript makes **browser-side** calls to other services — an API, an auth
+emulator, a CDN stub — and from the remote machine every `localhost` URL in
+those calls points at the wrong computer. Symptoms arrive one layer at a time
+(page loads → login fails → API calls fail), so find them all up front instead:
+
+- **Grep the frontend's env files and config for `localhost:`** (`.env*`,
+  `vite.config.*`, hardcoded URLs in `src/`). Each hit that the *browser* uses
+  is a service that must also be served — or the feature breaks remotely.
+  Server-to-server localhost calls are fine; only what the browser fetches
+  matters.
+
+- **Serve has exactly three HTTPS ports: 443, 8443, 10000.** That is the whole
+  budget — e.g. frontend on 443, API on 8443, auth emulator on 10000
+  (`tailscale serve --bg --https=8443 8080`). More than three services means
+  path-mounting or rethinking.
+
+- **Mixed content forces HTTPS for every one of them.** The page is now
+  `https://`, so a browser call to `http://localhost:9099` is blocked even on
+  the machine itself. Any URL the remote browser uses must go through a Serve
+  HTTPS mapping.
+
+- **Rewire the URLs.** Env-file entries (`BACKEND_URL` etc.) can simply point
+  at the ts.net URL — the serving machine can reach its own ts.net name, so
+  local browsing keeps working. For URLs hardcoded in client code, derive from
+  the page instead of editing in a constant, so both origins work at once:
+
+  ```js
+  const apiUrl = window.location.hostname === "localhost"
+    ? "http://localhost:9099"
+    : `https://${window.location.hostname}:10000`;
+  ```
+
+- **CORS: the API sees a new origin.** If the backend allowlists origins, add
+  `https://<machine>.<tailnet>.ts.net` (no port for 443) alongside the existing
+  localhost entry. Verify with a preflight before blaming anything else:
+
+  ```bash
+  curl -s -D - -o /dev/null -X OPTIONS http://127.0.0.1:8080/some/path \
+    -H "Origin: https://mbp.tailnet-name.ts.net" \
+    -H "Access-Control-Request-Method: GET" | grep -i access-control
+  ```
+
+  No `access-control-allow-origin` in the response → the server does not have
+  the origin yet.
+
+- **The frozen-env restart trap.** A server launched as
+  `dotenv -c -- node --watch server.js` snapshots its env at launch: editing
+  `.env.local` does nothing, and `--watch` restarts inherit the stale env. Only
+  restarting the whole script picks up the change — usually something the user
+  must do in their own terminal. Compare the listening PID's start time
+  (`ps -o pid,lstart -p <pid>`) against when the env was edited to prove this
+  is the problem before hunting elsewhere.
 
 ## When it does not work
 

--- a/configs/claude/skills/tailscale-serve/SKILL.md
+++ b/configs/claude/skills/tailscale-serve/SKILL.md
@@ -112,10 +112,13 @@ those calls points at the wrong computer. Symptoms arrive one layer at a time
   Server-to-server localhost calls are fine; only what the browser fetches
   matters.
 
-- **Serve has exactly three HTTPS ports: 443, 8443, 10000.** That is the whole
-  budget — e.g. frontend on 443, API on 8443, auth emulator on 10000
-  (`tailscale serve --bg --https=8443 8080`). More than three services means
-  path-mounting or rethinking.
+- **Give each service its own HTTPS port** with `--https`, e.g. frontend on 443,
+  API on 8443, auth emulator on 10000 (`tailscale serve --bg --https=8443 8080`).
+  Those three are the conventional choice, not a limit: the 443/8443/10000
+  allowlist belongs to Funnel, and Serve is not checked against it
+  (`verifyFunnelEnabled` runs only in the funnel path), so a fourth service can
+  take any port you like. Path-mounting with `--set-path` is the alternative
+  when you would rather keep everything on one port.
 
 - **Mixed content forces HTTPS for every one of them.** The page is now
   `https://`, so a browser call to `http://localhost:9099` is blocked even on


### PR DESCRIPTION
## Summary
Updates `configs/claude/skills/tailscale-serve/SKILL.md` with lessons from serving a real multi-service dev app:

- Run `tailscale serve` with a ~30 s timeout — a hang means it is sitting on an enablement prompt.
- **Verify before reporting**: one `curl` of the ts.net URL catches proxy problems and the Vite host-check block.
- New **"Multi-service apps"** section: grep the frontend for browser-side `localhost:` URLs up front; give each service its own HTTPS port; mixed-content means every browser-facing service needs an HTTPS mapping; rewire URLs by origin so local and remote both work; CORS allowlist + a preflight check; the frozen-env restart trap (`dotenv -c -- node --watch` snapshots env at launch).

Docs only — no code changes.

## Correction in the second commit

The first draft said Serve has "exactly three HTTPS ports: 443, 8443, 10000 — that is the whole budget". That allowlist is **Funnel's**, not Serve's. In `cmd/tailscale/cli/serve_v2.go` the check is reached only from the funnel path:

```go
if funnel {
    // verify node has funnel capabilities
    if err := e.verifyFunnelEnabled(ctx, 443); err != nil {
```

which leads to `CheckFunnelAccess` → `CheckFunnelPort` (`ipn/serve.go`). Nothing validates `--https` for serve, so a fourth service can take a fourth port. The bullet now presents 443/8443/10000 as the conventional choice rather than a cap, and offers `--set-path` as the alternative instead of the forced fallback.

## Test plan
- [x] `bats test/makefile.bats` skill checks (frontmatter name / description) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
