### PR TITLE
fix(zsh): guard the asdf source so a machine without it starts clean

### DIFF
--- a/.zsh/10-os.zsh
+++ b/.zsh/10-os.zsh
@@ -1,10 +1,17 @@
+# asdf comes from a git clone rather than a package, so it is not always there:
+# a machine that has not run install.sh yet, a container, CI. Guard the source
+# -- unguarded it wrote "no such file or directory" to stderr on every start,
+# two lines before the message below that explains how to install it.
+#
+# Both branches did this identically, so it lives ahead of the case. That keeps
+# the order they had: asdf first, then the PATH entries that should win over
+# its shims.
+export ASDF_DIR="$HOME/.asdf"
+[ -f "$ASDF_DIR/asdf.sh" ] && . "$ASDF_DIR/asdf.sh"
+
 # Set option depending on OS
 case "${OS}" in
     Darwin*)
-        # ASDF config - expected to be cloned from git
-        export ASDF_DIR="$HOME/.asdf"
-        # initialize asdf
-        . "$HOME/.asdf/asdf.sh"
         # Add Brew Path
         export PATH="/opt/homebrew/bin:$PATH"
         export PATH=$HOME/.local/share/bob/nvim-bin:$PATH
@@ -17,9 +24,6 @@ case "${OS}" in
         fi
     ;;
     Linux*)
-        # ASDF config - expected to be cloned from git
-        export ASDF_DIR="$HOME/.asdf"
-        . "$HOME/.asdf/asdf.sh"
         # Allow using ssh-add command
         eval "$(ssh-agent)"
         # set pbcopy to be similar to Darwin

--- a/.zsh/74-peco-fzf.zsh
+++ b/.zsh/74-peco-fzf.zsh
@@ -24,7 +24,11 @@ bindkey '^Z' peco-history-selection
 
 autoload -Uz compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
-complete -o nospace -C /opt/homebrew/bin/terraform terraform
+# terraform ships its own completion helper; register it against wherever the
+# binary actually is rather than an Intel/Apple Silicon Homebrew path.
+if (( $+commands[terraform] )); then
+  complete -o nospace -C "${commands[terraform]}" terraform
+fi
 
 # fzf settings
 export FZF_CTRL_T_COMMAND='rg --files --hidden --follow --glob "!.git/*"'

--- a/test/startup.bats
+++ b/test/startup.bats
@@ -70,6 +70,38 @@ startup_stdout() {
   grep -q 'num  calls' <<<"$output"
 }
 
+# --- stderr ------------------------------------------------------------------
+
+# asdf is a git clone, not a package, so "not installed yet" is a normal state
+# for a fresh machine, a container or CI. The modules may advise you to install
+# it; they may not fail trying to load it (#302).
+startup_stderr() {
+  env "$@" zsh -c "source '$REPO/.zshrc'" 2>&1 >/dev/null
+}
+
+@test "a machine without asdf gets advice, not a load error" {
+  local home
+  home="$(mktemp -d)"
+
+  run startup_stderr HOME="$home"
+  rm -rf "$home"
+
+  ! grep -q 'asdf.sh' <<<"$output"
+  ! grep -q 'no such file or directory' <<<"$output"
+}
+
+@test "asdf is still sourced when it is there" {
+  local home
+  home="$(mktemp -d)"
+  mkdir -p "$home/.asdf"
+  echo 'export ASDF_WAS_SOURCED=1' >"$home/.asdf/asdf.sh"
+
+  run env HOME="$home" zsh -c "source '$REPO/.zshrc'; print \"sourced=\$ASDF_WAS_SOURCED\"" 2>/dev/null
+  rm -rf "$home"
+
+  grep -q '^sourced=1$' <<<"$output"
+}
+
 # --- structure ---------------------------------------------------------------
 
 @test "the timer lives in the loader, not in a module" {


### PR DESCRIPTION
Closes #302.

## Before

```
$ HOME=$(mktemp -d) zsh -c 'source .zshrc' 2>&1 >/dev/null | head -1
.zsh/10-os.zsh:.:22: no such file or directory: /tmp/tmp.XXXX/.asdf/asdf.sh
```

`.zsh/10-os.zsh` sourced `~/.asdf/asdf.sh` unconditionally in **both** branches, while two lines below it already handled the missing-asdf case by printing install instructions. The error arrived before the advice.

## After

The two branches had the identical pair of lines, so they move ahead of the `case` with a guard:

```zsh
export ASDF_DIR="$HOME/.asdf"
[ -f "$ASDF_DIR/asdf.sh" ] && . "$ASDF_DIR/asdf.sh"
```

Relative order is unchanged — asdf still loads before the PATH entries meant to win over its shims (`/opt/homebrew/bin` on macOS, linuxbrew/snap on Linux). fish already guarded its own asdf load, so this closes that gap between the shells too.

Same shape one file over, also named in the issue: `.zsh/74-peco-fzf.zsh` hardcoded `complete -C /opt/homebrew/bin/terraform` — an **Intel** Homebrew path, wrong on Apple Silicon and on Linux. Now registered against `$commands[terraform]`, and only when terraform is installed.

## Verified

```
asdf.sh errors on stderr (fake HOME):  0
ASDF_WAS_SOURCED=1                     (stub asdf.sh in place → still sourced)
ASDF_DIR=/tmp/tmp.XXXX/.asdf
```

## Tests

Two tests added to `test/startup.bats` (now 8):

- a machine without asdf gets advice, not a load error
- asdf is still sourced when it is there — the guard must not turn into "never load"

Both checked by breaking what they cover:

| Break | Result |
| --- | --- |
| drop the `-f` guard | test 6 fails |
| replace the source with `:` | test 7 fails |

Full suite green: `startup` 8, `makefile` 21, `scripts` 23, `aliases` 11, `fish-config` 12, `prompt` 10.

Note the `ssh-agent` line visible in the diff context is #303, next up — the suite stubs it out so these tests do not depend on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_