### PR TITLE
fix(zsh): reuse one ssh-agent instead of starting one per shell

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -117,6 +117,10 @@ jobs:
       # A shell that prints on every start corrupts whatever reads its stdout.
       - name: Run startup tests
         run: bats test/startup.bats
+      # One ssh-agent per machine, not one per shell. Stubbed, so no agent is
+      # started on the runner.
+      - name: Run ssh-agent tests
+        run: bats test/ssh-agent.bats
 
   gitleaks:
     runs-on: ubuntu-latest

--- a/.zsh/10-os.zsh
+++ b/.zsh/10-os.zsh
@@ -44,7 +44,14 @@ case "${OS}" in
             # Nothing is listening, so the socket is a leftover from an agent
             # that died; ssh-agent -a refuses to bind over it.
             rm -f "$_ssh_agent_sock"
-            eval "$(ssh-agent -a "$_ssh_agent_sock" 2>/dev/null)" >/dev/null
+            # Deliberately not `eval "$(ssh-agent ...)"`: the daemon it forks
+            # inherits the command substitution's pipe and never closes it, so
+            # anything reading this shell's output waits for the agent to exit.
+            # That is what hung a CI job for 34 minutes. We named the socket, so
+            # the environment it would have printed is already known.
+            if ssh-agent -a "$_ssh_agent_sock" >/dev/null 2>&1 </dev/null; then
+                export SSH_AUTH_SOCK="$_ssh_agent_sock"
+            fi
         fi
         unset _ssh_agent_sock
         # set pbcopy to be similar to Darwin

--- a/.zsh/10-os.zsh
+++ b/.zsh/10-os.zsh
@@ -24,8 +24,29 @@ case "${OS}" in
         fi
     ;;
     Linux*)
-        # Allow using ssh-add command
-        eval "$(ssh-agent)"
+        # One agent per machine, not one per shell. `eval "$(ssh-agent)"` on
+        # every start left a stray agent behind for every terminal ever opened,
+        # and each shell got its own: a key added with ssh-add in one window
+        # was invisible in the next.
+        #
+        # So point every shell at the same socket -- reuse the agent answering
+        # there, and only start one when nothing does. macOS needs none of this
+        # because launchd already runs an agent; the Darwin branch above just
+        # finds its socket again.
+        _ssh_agent_sock="${XDG_RUNTIME_DIR:-/tmp}/ssh-agent-$UID.sock"
+        # ssh-add -l exits 1 for "agent is there, holding no keys" and 2 for
+        # "could not reach an agent" -- only the second one means we need one.
+        if [[ -n "$SSH_AUTH_SOCK" ]] && { ssh-add -l >/dev/null 2>&1 || [[ $? -ne 2 ]] }; then
+            : # an agent is already reachable (forwarded over SSH, systemd, ...)
+        elif [[ -S "$_ssh_agent_sock" ]] && { SSH_AUTH_SOCK="$_ssh_agent_sock" ssh-add -l >/dev/null 2>&1 || [[ $? -ne 2 ]] }; then
+            export SSH_AUTH_SOCK="$_ssh_agent_sock"
+        elif command -v ssh-agent >/dev/null 2>&1; then
+            # Nothing is listening, so the socket is a leftover from an agent
+            # that died; ssh-agent -a refuses to bind over it.
+            rm -f "$_ssh_agent_sock"
+            eval "$(ssh-agent -a "$_ssh_agent_sock" 2>/dev/null)" >/dev/null
+        fi
+        unset _ssh_agent_sock
         # set pbcopy to be similar to Darwin
         alias pbcopy='xsel --clipboard --input'
         # Check if required commands are installed

--- a/test/ssh-agent.bats
+++ b/test/ssh-agent.bats
@@ -62,7 +62,12 @@ STUB_ADD
 }
 
 teardown() {
+  # Belt and braces: an agent that outlived a test would hold the pipe bats
+  # reads from and hang the run rather than fail it. Only ones bound to this
+  # test's socket are matched.
+  [ -n "${RUNTIME:-}" ] && pkill -f "ssh-agent -a $RUNTIME" 2>/dev/null
   [ -n "${TMP:-}" ] && rm -rf "$TMP"
+  return 0
 }
 
 # Report SSH_AUTH_SOCK as the shell ends up with it.
@@ -121,15 +126,20 @@ s.listen(1)' "$forwarded"
 
 @test "no ssh-agent installed is not an error" {
   # Containers and CI images often have no openssh-client at all.
-  rm -f "$STUB/ssh-agent" "$STUB/ssh-add"
-  cat >"$STUB/ssh-add" <<'STUB_ADD'
-#!/bin/sh
-exit 2
-STUB_ADD
-  chmod +x "$STUB/ssh-add"
+  #
+  # PATH is the stub directory ALONE: dropping the stub while the rest of PATH
+  # is still there finds the runner's real /usr/bin/ssh-agent, which starts a
+  # daemon that inherits the pipe bats reads and hangs the job. Other commands
+  # go missing along with it, which is noisy but harmless -- the assertion only
+  # looks at whether ssh-agent was reached.
+  rm -f "$STUB/ssh-agent"
+  local zsh_bin
+  zsh_bin="$(command -v zsh)" # PATH will not be able to find it in a moment
 
-  run env PATH="$STUB:$PATH" XDG_RUNTIME_DIR="$RUNTIME" SSH_AUTH_SOCK= \
-    zsh -c "source '$REPO/.zshrc'" 2>&1 >/dev/null
+  run env PATH="$STUB" XDG_RUNTIME_DIR="$RUNTIME" SSH_AUTH_SOCK= \
+    "$zsh_bin" -c "source '$REPO/.zshrc'; print \"sock=\$SSH_AUTH_SOCK\"" 2>&1
 
   ! grep -q 'ssh-agent' <<<"$output"
+  grep -q '^sock=$' <<<"$output"
+  [ "$(agents_started)" -eq 0 ]
 }

--- a/test/ssh-agent.bats
+++ b/test/ssh-agent.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+
+# Tests for the ssh-agent handling in .zsh/10-os.zsh (Linux branch).
+#
+# It used to be `eval "$(ssh-agent)"`, which started a fresh agent for every
+# shell: stray processes for every terminal ever opened, and a key added in one
+# window missing from the next (#303). What replaced it has to hold three
+# properties, so all three are pinned here:
+#
+#   1. start an agent when nothing is reachable
+#   2. reuse it in later shells rather than starting another
+#   3. never displace an agent that is already reachable (SSH forwarding)
+#
+# ssh-agent and ssh-add are stubbed. Real ones would leave agents behind on the
+# machine running the tests, and a stub can be made to fail on demand, which is
+# what the stale-socket case needs. The stub mimics the exit codes the real
+# ssh-add uses: 2 for "could not reach an agent", 1 for "agent, but no keys".
+#
+# Run locally with `bats test/ssh-agent.bats` (brew install bats-core).
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  TMP="$(mktemp -d)"
+  RUNTIME="$TMP/run"
+  STUB="$TMP/bin"
+  AGENT_LOG="$TMP/starts"
+  mkdir -p "$RUNTIME" "$STUB"
+  : >"$AGENT_LOG"
+
+  # A bound AF_UNIX socket leaves its filesystem entry behind after the process
+  # exits, which is exactly what a real agent's socket looks like to `-S`.
+  cat >"$STUB/ssh-agent" <<'STUB_AGENT'
+#!/bin/sh
+echo "start $*" >>"$AGENT_LOG"
+sock=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -a) sock="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ -n "$sock" ]; then
+  python3 -c 'import socket, sys
+s = socket.socket(socket.AF_UNIX)
+s.bind(sys.argv[1])
+s.listen(1)' "$sock"
+  : >"$sock.alive"
+fi
+echo "SSH_AUTH_SOCK=$sock; export SSH_AUTH_SOCK;"
+STUB_AGENT
+
+  # Reachable only while the marker is there, so a socket can be left behind
+  # without an agent answering on it.
+  cat >"$STUB/ssh-add" <<'STUB_ADD'
+#!/bin/sh
+[ -n "$SSH_AUTH_SOCK" ] && [ -f "$SSH_AUTH_SOCK.alive" ] && exit 1
+exit 2
+STUB_ADD
+
+  chmod +x "$STUB/ssh-agent" "$STUB/ssh-add"
+  export AGENT_LOG
+}
+
+teardown() {
+  [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+# Report SSH_AUTH_SOCK as the shell ends up with it.
+start_shell() {
+  env PATH="$STUB:$PATH" XDG_RUNTIME_DIR="$RUNTIME" "$@" \
+    zsh -c "source '$REPO/.zshrc'; print \"sock=\$SSH_AUTH_SOCK\"" 2>/dev/null |
+    grep '^sock='
+}
+
+agents_started() {
+  wc -l <"$AGENT_LOG" | tr -d ' '
+}
+
+@test "starts an agent when none is reachable" {
+  run start_shell SSH_AUTH_SOCK=
+  [ "$output" = "sock=$RUNTIME/ssh-agent-$(id -u).sock" ]
+  [ "$(agents_started)" -eq 1 ]
+}
+
+@test "a second shell reuses the running agent" {
+  start_shell SSH_AUTH_SOCK= >/dev/null
+  run start_shell SSH_AUTH_SOCK=
+
+  [ "$output" = "sock=$RUNTIME/ssh-agent-$(id -u).sock" ]
+  # The regression this whole file exists for: one agent, not one per shell.
+  [ "$(agents_started)" -eq 1 ]
+}
+
+@test "an agent already reachable is left alone" {
+  # What SSH agent forwarding looks like: SSH_AUTH_SOCK points somewhere else
+  # entirely, and something is answering on it.
+  local forwarded="$TMP/forwarded.sock"
+  python3 -c 'import socket, sys
+s = socket.socket(socket.AF_UNIX)
+s.bind(sys.argv[1])
+s.listen(1)' "$forwarded"
+  : >"$forwarded.alive"
+
+  run start_shell SSH_AUTH_SOCK="$forwarded"
+
+  [ "$output" = "sock=$forwarded" ]
+  [ "$(agents_started)" -eq 0 ]
+}
+
+@test "a socket left by a dead agent is replaced" {
+  start_shell SSH_AUTH_SOCK= >/dev/null
+  # The agent goes away; its socket file stays behind. ssh-agent -a will not
+  # bind over it, so the config has to clear it first.
+  rm -f "$RUNTIME/ssh-agent-$(id -u).sock.alive"
+
+  run start_shell SSH_AUTH_SOCK=
+
+  [ "$output" = "sock=$RUNTIME/ssh-agent-$(id -u).sock" ]
+  [ "$(agents_started)" -eq 2 ]
+}
+
+@test "no ssh-agent installed is not an error" {
+  # Containers and CI images often have no openssh-client at all.
+  rm -f "$STUB/ssh-agent" "$STUB/ssh-add"
+  cat >"$STUB/ssh-add" <<'STUB_ADD'
+#!/bin/sh
+exit 2
+STUB_ADD
+  chmod +x "$STUB/ssh-add"
+
+  run env PATH="$STUB:$PATH" XDG_RUNTIME_DIR="$RUNTIME" SSH_AUTH_SOCK= \
+    zsh -c "source '$REPO/.zshrc'" 2>&1 >/dev/null
+
+  ! grep -q 'ssh-agent' <<<"$output"
+}


### PR DESCRIPTION
Closes #303.

## Before

```zsh
Linux*)
    # Allow using ssh-add command
    eval "$(ssh-agent)"
```

Unconditional, so every terminal, every tmux pane and every `zsh -c` started another agent and left it running. They were also mutually invisible: `ssh-add` loaded the key into *that* shell's agent, and the next window — holding a different `SSH_AUTH_SOCK` — asked for the passphrase again.

## After

One socket per user, taken in order of preference:

1. **An agent already reachable via `SSH_AUTH_SOCK`** → leave it alone. This is the SSH-forwarding case, and displacing it breaks the remote session's access to your keys.
2. **The socket in `XDG_RUNTIME_DIR`** (falling back to `/tmp`) → reuse it.
3. **Nothing answers** → start an agent bound to that socket, clearing a socket left behind by a dead agent first, since `ssh-agent -a` refuses to bind over one.

`ssh-add -l` exits **1** for "agent is there, holding no keys" and **2** for "could not reach an agent", so the probe accepts 1 — treating it as failure would restart an agent that was running fine but empty. If `ssh-agent` is not installed at all (containers, CI images), nothing happens and nothing is printed.

macOS is untouched: launchd runs the agent there, and the Darwin branch above only has to find its socket again.

## Tests

New `test/ssh-agent.bats` (5), wired into the CI bats job:

| Test | Pins |
| --- | --- |
| starts an agent when none is reachable | the feature still works |
| a second shell reuses the running agent | **the regression itself** — one agent, not one per shell |
| an agent already reachable is left alone | SSH agent forwarding survives |
| a socket left by a dead agent is replaced | no permanent wedge after a reboot/kill |
| no ssh-agent installed is not an error | containers stay quiet |

`ssh-agent`/`ssh-add` are stubbed — real ones would leave agents on whatever machine runs the tests, and the stale-socket case needs an agent that can be made to stop answering. The stub reproduces the real exit codes (2 = unreachable, 1 = no identities) and binds a real AF_UNIX socket so the `-S` test sees what it would see in production.

Reverting `.zsh/10-os.zsh` to `eval "$(ssh-agent)"` fails all 5.

Full suite green: `ssh-agent` 5, `startup` 8, `makefile` 21, `scripts` 23, `aliases` 11, `fish-config` 12, `prompt` 10 — and `pgrep -c ssh-agent` is 0 after the run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_