### PR TITLE
fix(zsh): derive $DOTFILES from the repository instead of a macOS path

### DIFF
--- a/.zsh/30-runtimes.zsh
+++ b/.zsh/30-runtimes.zsh
@@ -33,6 +33,13 @@ autoload -Uz vcs_info
 
 
 
-# Path to dotfiles repository
-export DOTFILES="/Users/`whoami`/.ghq/github.com/Naturalclar/dotfiles"
+# Path to dotfiles repository.
+#
+# Derived from this file rather than spelled out: the literal it replaced began
+# /Users/<name>/.ghq/..., so it was wrong on Linux and WSL, wrong for a clone
+# kept anywhere other than under ghq, and wrong for a worktree.
+#
+# %N is the file being sourced, :A resolves it through the ~/.zshrc symlink,
+# and the two :h take .zsh/30-runtimes.zsh up to the repository root.
+export DOTFILES="${${(%):-%N}:A:h:h}"
 

--- a/test/startup.bats
+++ b/test/startup.bats
@@ -102,6 +102,36 @@ startup_stderr() {
   grep -q '^sourced=1$' <<<"$output"
 }
 
+# --- $DOTFILES ---------------------------------------------------------------
+
+# It used to be the literal /Users/`whoami`/.ghq/github.com/Naturalclar/dotfiles
+# (#304): wrong on Linux and WSL, and wrong for a clone kept anywhere else.
+# Deriving it from the module's own path is only correct if it survives the
+# ~/.zshrc symlink, which is how every real shell reaches it.
+
+@test "DOTFILES points at this repository" {
+  run env zsh -c "source '$REPO/.zshrc'; print \"dotfiles=\$DOTFILES\"" 2>/dev/null
+  grep -q "^dotfiles=$REPO\$" <<<"$output"
+}
+
+@test "DOTFILES survives being reached through the ~/.zshrc symlink" {
+  local home
+  home="$(mktemp -d)"
+  ln -s "$REPO/.zshrc" "$home/.zshrc"
+
+  run env HOME="$home" zsh -c "source '$home/.zshrc'; print \"dotfiles=\$DOTFILES\"" 2>/dev/null
+  rm -rf "$home"
+
+  grep -q "^dotfiles=$REPO\$" <<<"$output"
+}
+
+@test "DOTFILES is a directory holding the Makefile" {
+  # cpdf copies into it, so a stale path would scatter files into a directory
+  # that does not exist rather than fail.
+  run env zsh -c "source '$REPO/.zshrc'; [[ -f \$DOTFILES/Makefile ]] && print ok" 2>/dev/null
+  grep -q '^ok$' <<<"$output"
+}
+
 # --- structure ---------------------------------------------------------------
 
 @test "the timer lives in the loader, not in a module" {


### PR DESCRIPTION
Closes #304.

## Before

```zsh
export DOTFILES="/Users/`whoami`/.ghq/github.com/Naturalclar/dotfiles"
```

Wrong on Linux and WSL (`/home/...`), wrong for a clone kept anywhere other than under ghq, wrong in a worktree. `cpdf` (`cp -r $(ls -a | pf) $DOTFILES`) is the consumer, so a bad value doesn't fail loudly — it copies somewhere unexpected.

## After

```zsh
export DOTFILES="${${(%):-%N}:A:h:h}"
```

The same trick `.zshrc` already uses to find `.zsh/`, one level down: `%N` is the file being sourced, `:A` resolves it through the `~/.zshrc` symlink, and the two `:h` take `.zsh/30-runtimes.zsh` up to the repository root. The backticks go with it.

Verified both ways in:

```
direct source:            /home/user/dotfiles
through ~/.zshrc symlink: /home/user/dotfiles
```

## Tests

Three added to `test/startup.bats` (now 11):

- DOTFILES points at this repository
- DOTFILES survives being reached through the `~/.zshrc` symlink — the path every real shell takes, and the one that makes `%N`-derivation non-obvious
- DOTFILES is a directory holding the Makefile — `cpdf` needs a real destination

Checked by breaking it two ways:

| Break | Result |
| --- | --- |
| restore the hardcoded `/Users/...` literal | all three fail |
| one `:h` too few (points at `.zsh/`) | all three fail |

Full suite green: `startup` 11, `ssh-agent` 5, `makefile` 21, `scripts` 23, `aliases` 11, `fish-config` 12, `prompt` 10.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_