### PR TITLE
docs: make AGENTS.md point at CLAUDE.md instead of copying it

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,6 +121,10 @@ jobs:
       # started on the runner.
       - name: Run ssh-agent tests
         run: bats test/ssh-agent.bats
+      # Docs drift silently; this suite also fails if a new bats suite is not
+      # documented or not given a step here.
+      - name: Run docs tests
+        run: bats test/docs.bats
 
   gitleaks:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,61 +1,15 @@
 # AGENTS.md
 
-This file provides guidance to coding agents (Codex, etc.) when working with code in this repository. It mirrors `CLAUDE.md` — keep the two in sync when updating either.
+**The guidance for this repository lives in [`CLAUDE.md`](CLAUDE.md). Read that
+file before making changes — it applies to every coding agent, not just Claude
+Code.**
 
-## Commands
+It covers the make targets, what CI checks, how `.zshrc` and `.zsh/*.zsh` are
+arranged, which tools the config assumes, and the code style to match.
 
-- `make` or `make dotfiles` — symlink all dotfiles (`.??*` except `.git`, `.gitignore`, etc.) into `$HOME`
-- `make config` — symlink `.config/*` entries into `$HOME/.config/`
-- `make claude` — symlink `configs/claude/settings.json` to `~/.claude/settings.json` (Claude Code hooks etc.; machine-local state like `feedbackSurveyState` is intentionally not committed)
-- `make vscodeExtensions` — sync VSCode extensions via `configs/.vscode/vscodeSync.sh`
-- `make list` — show which dotfiles will be symlinked
-- `make help` — print all make targets
-- Windows setup: run `./bootstrap.ps1` to concatenate `windows/*.ps1` into the PowerShell `$PROFILE`
-
-## CI
-
-- **lint.yml** — checks `.zshrc` syntax with `zsh -n` and sources it on Ubuntu
-- **make.yml** — runs `make` on macOS
-
-## Architecture
-
-This is a cross-platform dotfiles repo (macOS, Linux/WSL, Windows). The core mechanism is simple: `make dotfiles` creates symlinks from this repo into `$HOME`.
-
-### Key files
-- `.zshrc` — main shell config; defines aliases, functions, PATH setup, keybindings. OS-specific blocks use `uname` detection (Darwin/Linux/Msys)
-- `.config/nvim/` — Neovim config using LazyVim framework (`config/lazy.lua` bootstraps lazy.nvim, plugins in `lua/plugins/`)
-- `.config/fish/` — Fish shell config (experimental, best-effort). `.zshrc` is the source of truth for aliases and functions; fish carries only a subset. An alias defined in both shells must behave identically — add it to `.zshrc` first
-- `configs/.vscode/` — VSCode settings, keybindings, and extension sync script
-- `.scripts/` — custom CLI tools added to PATH (`duck`, `google`, `pmux`, `git-worktree-pull`)
-- `powershell/` — komorebi window manager start/stop scripts
-- `ahk/` — AutoHotKey scripts (remap keys, language switching, shortcuts)
-- `keymaps/` — custom keyboard layout mappings
-- `.config/kitty/`, `.config/hypr/`, `.config/i3/`, `.config/waybar/` — terminal and WM configs
-
-### Key tools assumed installed
-- **ghq** — repository management (`ghq get`, `ghq list`)
-- **peco/fzf** — fuzzy selection (workspace switching, history, script selection)
-- **asdf** — version manager for Node.js, Java, etc.
-- **lazygit** — terminal git UI (aliased as `lg`)
-
-### Notable shell functions
-- `run-script` (alias `rs`, keybind `Ctrl+N`) — fzf-based package.json script selector; auto-detects package manager from lockfile
-- `peco-workspace` (alias `ws`, keybind `Ctrl+W`) — cd to ghq-managed repos via peco
-- `fzf-workspace` (alias `wf`, keybind `Ctrl+A`) — cd to ghq-managed repos via fzf with README preview
-- `peco-history-selection` (keybind `Ctrl+Z`) — search shell history
-
-### Testing
-Tests are in `test/`. Each subdirectory has a `package.json` for testing the `run-script` function:
-- `cd test/test-package-scripts && rs` — test basic script selection
-- `cd test/test-colon-scripts && rs` — test scripts with colons in names
-
-## Code Style
-
-- Match existing formatting in each file
-- Shell scripts: prefer POSIX-compatible syntax when possible
-- PowerShell scripts: follow Microsoft best practices
-- The `.zshrc` uses vi mode (`set -o vi`)
-
-## Environment Variables
-
-Secret API keys go in `~/.config/secrets/credentials.sh` (auto-sourced by `.zshrc`, gitignored).
+This file used to carry its own copy of all of that, and the copy went stale:
+it still described `.zshrc` as the main config months after it became a loader,
+and still sent Windows setup through `bootstrap.ps1` after `install.ps1` became
+the entry point. Two files promising to mirror each other drift the moment one
+is edited alone, so this one deliberately holds nothing to drift — if you came
+here for the details, they are one file over.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## CI
 
 - **lint.yml** — checks `.zshrc` and each `.zsh/*.zsh` module with `zsh -n`, sources the whole config, then runs shellcheck, actionlint, gitleaks and the bats suites on Ubuntu
-- **make.yml** — runs `make` on macOS
+- **make.yml** — runs `bats test/makefile.bats` and then `make` itself, on macOS and Ubuntu (the Makefile hits GNU vs BSD differences that only show up per-OS)
 - PowerShell scripts are parsed and linted with PSScriptAnalyzer on Ubuntu (`pwsh` needs no Windows runner for that); nothing exercises them on Windows
 
 ## Architecture
@@ -24,7 +24,7 @@ This is a cross-platform dotfiles repo (macOS, Linux/WSL, Windows). The core mec
 
 ### Key files
 - `.zshrc` — loader only; sources `.zsh/*.zsh` in filename order
-- `.zsh/*.zsh` — the actual shell config, split by concern. The numeric prefix is load order and matters: `00` options/locale, `10` OS-specific (`uname` detection for Darwin/Linux/Msys), `20` history, `30` runtimes, `40` prompt, `50` PATH, `60` plugins, `70`–`75` aliases and widgets, `80`+ late setup. Concatenating them in order reproduces the single file they replaced
+- `.zsh/*.zsh` — the actual shell config, split by concern. The numeric prefix is load order and matters: `00` options/locale, `10` OS-specific (`uname` detection for Darwin/Linux/Msys), `20` history, `30` runtimes, `40` prompt, `50` PATH, `60` plugins, `70`–`75` aliases and widgets, `80`+ late setup. The split was byte-for-byte at the time it happened; the modules have since been edited on their own
 - `.config/nvim/` — Neovim config using LazyVim framework (`config/lazy.lua` bootstraps lazy.nvim, plugins in `lua/plugins/`)
 - `.config/fish/` — Fish shell config (experimental, best-effort). zsh is the source of truth for aliases and functions; fish carries only a subset. An alias defined in both shells must behave identically — add it to the matching `.zsh/*.zsh` module first
 - `configs/.vscode/` — VSCode settings, keybindings, and extension sync script
@@ -49,7 +49,19 @@ This is a cross-platform dotfiles repo (macOS, Linux/WSL, Windows). The core mec
 - `peco-history-selection` (keybind `Ctrl+Z`) — search shell history
 
 ### Testing
-Tests are in `test/`. Each subdirectory has a `package.json` for testing the `run-script` function:
+Tests are in `test/`, as bats-core suites (`brew install bats-core`, then `bats test/<name>.bats`). Every suite runs in CI, and each is described in `test/README.md` — add a section there for a new one, and a step in the workflow that runs it:
+- `scripts.bats` — the non-interactive behavior of the tools in `.scripts/`
+- `aliases.bats` — zsh/fish/PowerShell alias parity, and duplicate definitions
+- `prompt.bats` — `_prompt_path` from `.zsh/40-prompt.zsh`
+- `fish-config.bats` — the parts of `.config/fish/` that mirror `.zsh/`
+- `makefile.bats` — the symlink targets, against a throwaway `$HOME`
+- `startup.bats` — what a new shell prints, and `$DOTFILES`
+- `ssh-agent.bats` — one agent per machine rather than one per shell
+- `docs.bats` — the docs still match the repository, and every suite here is documented and run
+
+Sourcing `.zshrc` in a test starts background processes that can hold the runner's pipes open — stub them, or the job hangs long after the tests pass.
+
+Two directories are for trying `run-script` by hand, each with its own `package.json`:
 - `cd test/test-package-scripts && rs` — test basic script selection
 - `cd test/test-colon-scripts && rs` — test scripts with colons in names
 

--- a/test/README.md
+++ b/test/README.md
@@ -15,7 +15,7 @@ bats test/scripts.bats
 
 ### fish-config.bats
 
-Automated [bats-core](https://github.com/bats-core/bats-core) tests for the parts of `.config/fish/` that mirror `.zshrc`: `.scripts` being on `PATH`, and the UTF-8 locale forcing that keeps multibyte output readable over SSH clients like Termius. Both fail silently when missing — the shell still starts, the scripts just are not there and text breaks — so each is asserted directly, with a stub `locale` used to vary which locales are available. A final test checks that fish and zsh pick the *same* locale from the same input. Needs `fish`; these run in CI on every push. Locally:
+Automated [bats-core](https://github.com/bats-core/bats-core) tests for the parts of `.config/fish/` that mirror `.zsh/`: `.scripts` being on `PATH`, and the UTF-8 locale forcing that keeps multibyte output readable over SSH clients like Termius. Both fail silently when missing — the shell still starts, the scripts just are not there and text breaks — so each is asserted directly, with a stub `locale` used to vary which locales are available. A final test checks that fish and zsh pick the *same* locale from the same input. Needs `fish`; these run in CI on every push. Locally:
 
 ```bash
 brew install bats-core
@@ -24,7 +24,7 @@ bats test/fish-config.bats
 
 ### prompt.bats
 
-Automated [bats-core](https://github.com/bats-core/bats-core) tests for `_prompt_path` in `.zshrc`, which replaces the working directory in the prompt with `<repo>[/<worktree>]` plus the path from the repository root. Each test covers one of the things the logic is easy to get wrong: `--git-common-dir` coming back relative from a subdirectory, detecting a linked worktree by `<root>/.git` being a file, and doubling `%` so a directory name cannot corrupt the prompt. The function is pulled out of `.zshrc` on its own, so the rest of the file does not have to be loadable. Needs `zsh`; these run in CI on every push. Locally:
+Automated [bats-core](https://github.com/bats-core/bats-core) tests for `_prompt_path` in `.zsh/40-prompt.zsh`, which replaces the working directory in the prompt with `<repo>[/<worktree>]` plus the path from the repository root. Each test covers one of the things the logic is easy to get wrong: `--git-common-dir` coming back relative from a subdirectory, detecting a linked worktree by `<root>/.git` being a file, and doubling `%` so a directory name cannot corrupt the prompt. The function is pulled out of the module on its own, so the rest of the config does not have to be loadable. Needs `zsh`; these run in CI on every push. Locally:
 
 ```bash
 brew install bats-core
@@ -33,7 +33,7 @@ bats test/prompt.bats
 
 ### aliases.bats
 
-Automated [bats-core](https://github.com/bats-core/bats-core) tests that keep `.zshrc` and `.config/fish/` from drifting apart. They enforce the rule documented in the root `README.md`: `.zshrc` is the source of truth, and an alias defined in **both** shells must expand to the same thing. Fish is not required to carry every zsh alias — only to agree on the ones it does carry. A second check catches an alias defined twice in `.zshrc`, where the later definition silently wins. These run in CI on every push; locally:
+Automated [bats-core](https://github.com/bats-core/bats-core) tests that keep `.zsh/*.zsh`, `.config/fish/` and `windows/*.ps1` from drifting apart. They enforce the rule documented in the root `README.md`: zsh is the source of truth, and an alias defined in **both** shells must expand to the same thing. Fish is not required to carry every zsh alias — only to agree on the ones it does carry. A second check catches an alias defined twice across the `.zsh/*.zsh` modules, where the later definition silently wins. These run in CI on every push; locally:
 
 ```bash
 brew install bats-core
@@ -51,16 +51,34 @@ bats test/makefile.bats
 
 ### startup.bats
 
-Automated [bats-core](https://github.com/bats-core/bats-core) tests for what a new shell prints. A leftover profiling probe printed a bare millisecond count on every start, which corrupts anything reading that stdout, so the rule is asserted directly: a plain startup emits no number, no timing line and no profile table, while `ZSH_STARTUP_TIME=1` and `ZSH_PROFILE=1` each produce theirs. A last test keeps both markers in `.zshrc` rather than in a module — an end marker parked in one module stops covering whatever is added after it, which is how the old one came to miss three modules. Needs `zsh`; these run in CI on every push. Locally:
+Automated [bats-core](https://github.com/bats-core/bats-core) tests for what a new shell prints. A leftover profiling probe printed a bare millisecond count on every start, which corrupts anything reading that stdout, so the rule is asserted directly: a plain startup emits no number, no timing line and no profile table, while `ZSH_STARTUP_TIME=1` and `ZSH_PROFILE=1` each produce theirs. A last test keeps both markers in `.zshrc` rather than in a module — an end marker parked in one module stops covering whatever is added after it, which is how the old one came to miss three modules. Later tests cover `$DOTFILES` resolving to this repository through the `~/.zshrc` symlink, and a machine without asdf starting without a load error. Needs `zsh`; these run in CI on every push. Locally:
 
 ```bash
 brew install bats-core
 bats test/startup.bats
 ```
 
+### ssh-agent.bats
+
+Automated [bats-core](https://github.com/bats-core/bats-core) tests for the ssh-agent handling in `.zsh/10-os.zsh`. It used to run `eval "$(ssh-agent)"` on every start, so each shell got its own agent: stray processes for every terminal ever opened, and a key added in one window missing from the next. Three properties are pinned — start an agent when none is reachable, reuse it afterwards, and never displace one that is already reachable (which is what SSH agent forwarding looks like) — plus replacing a socket left by a dead agent, and staying quiet where `ssh-agent` is not installed. `ssh-agent` and `ssh-add` are stubbed: real ones would leave agents behind on the machine running the tests, and the stale-socket case needs an agent that can be made to stop answering. These run in CI on every push; locally:
+
+```bash
+brew install bats-core
+bats test/ssh-agent.bats
+```
+
+### docs.bats
+
+Automated [bats-core](https://github.com/bats-core/bats-core) tests that keep the documentation attached to the repository. `AGENTS.md` promised to mirror `CLAUDE.md`, then sat unchanged through the `.zshrc` split and ended up describing a file that no longer worked that way, so it is now a pointer rather than a copy — and these tests keep it one. The rest cover what rots in practice: a suite added without a section here, without a workflow step, or without a mention in `CLAUDE.md`, and a path named in the docs that no longer exists. These run in CI on every push; locally:
+
+```bash
+brew install bats-core
+bats test/docs.bats
+```
+
 ### test-package-scripts
 
-A test package to demonstrate the basic `run-script` function added to your .zshrc file. This test shows how to use the function to list and run npm scripts using fzf.
+A test package to demonstrate the basic `run-script` function from `.zsh/81-run-script.zsh`. This test shows how to use the function to list and run npm scripts using fzf.
 
 To use this test:
 
@@ -80,7 +98,7 @@ To use this test:
 
 ### test-colon-scripts
 
-A test package to demonstrate the `run-script` function with scripts that have colons in their names. This tests the functionality added to the .zshrc file that allows selecting and running npm scripts using fzf, with proper handling of script names containing colons.
+A test package to demonstrate the `run-script` function with scripts that have colons in their names. This tests the functionality in `.zsh/81-run-script.zsh` that allows selecting and running npm scripts using fzf, with proper handling of script names containing colons.
 
 To use this test:
 

--- a/test/docs.bats
+++ b/test/docs.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+# Tests that keep the documentation from drifting away from the repository.
+#
+# AGENTS.md promised to mirror CLAUDE.md and then sat unchanged through the
+# .zshrc split, so it described a file that no longer existed in that form and
+# sent Windows setup through the wrong script (#305). Two files that promise to
+# mirror each other drift the moment one is edited alone, so AGENTS.md now
+# points at CLAUDE.md instead of copying it, and that is asserted here.
+#
+# The other checks are about what actually goes stale in practice: a path that
+# was renamed, and a test suite that was added without being documented or run.
+#
+# Run locally with `bats test/docs.bats` (brew install bats-core).
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+}
+
+# --- AGENTS.md is a pointer, not a copy --------------------------------------
+
+@test "AGENTS.md sends the reader to CLAUDE.md" {
+  grep -q 'CLAUDE.md' "$REPO/AGENTS.md"
+}
+
+@test "AGENTS.md carries no second copy of the guidance" {
+  # A pointer is a few lines. Anything approaching CLAUDE.md's size means the
+  # content came back, and with it the drift.
+  local agents claude
+  agents=$(wc -l <"$REPO/AGENTS.md")
+  claude=$(wc -l <"$REPO/CLAUDE.md")
+
+  [ "$agents" -lt 30 ]
+  [ "$agents" -lt "$claude" ]
+}
+
+@test "AGENTS.md does not restate CLAUDE.md's sections" {
+  # The old copy had its own Commands / CI / Architecture / Code Style
+  # headings. Those are the ones that went out of date.
+  ! grep -qE '^## (Commands|CI|Architecture|Code Style|Environment Variables)' "$REPO/AGENTS.md"
+}
+
+# --- every suite is documented and run ---------------------------------------
+
+@test "every bats suite has a section in test/README.md" {
+  local missing=""
+  for suite in "$REPO"/test/*.bats; do
+    grep -q "^### $(basename "$suite")\$" "$REPO/test/README.md" || missing+=" $(basename "$suite")"
+  done
+  [ -z "$missing" ] || {
+    echo "undocumented suites:$missing"
+    false
+  }
+}
+
+@test "every bats suite is run by CI" {
+  # Adding a suite and forgetting the workflow step leaves it passing locally
+  # and never running anywhere else.
+  local missing=""
+  for suite in "$REPO"/test/*.bats; do
+    grep -qr "bats test/$(basename "$suite")" "$REPO/.github/workflows" || missing+=" $(basename "$suite")"
+  done
+  [ -z "$missing" ] || {
+    echo "suites no workflow runs:$missing"
+    false
+  }
+}
+
+@test "CLAUDE.md lists every bats suite" {
+  local missing=""
+  for suite in "$REPO"/test/*.bats; do
+    grep -q "$(basename "$suite")" "$REPO/CLAUDE.md" || missing+=" $(basename "$suite")"
+  done
+  [ -z "$missing" ] || {
+    echo "suites missing from CLAUDE.md:$missing"
+    false
+  }
+}
+
+# --- the paths the docs name still exist -------------------------------------
+
+@test "repository paths named in the docs exist" {
+  # Catches the rename half of doc rot: `.zshrc` splitting into `.zsh/`,
+  # `windows/keyboard.ps1` moving to `setup-defaults.ps1`, and so on. Only
+  # backticked tokens that look like paths into this repository are checked --
+  # not $HOME paths, globs or shell snippets.
+  local missing=""
+  local doc token
+  for doc in README.md CLAUDE.md AGENTS.md test/README.md docs/*.md; do
+    while IFS= read -r token; do
+      case "$token" in
+        *'*'* | *'~'* | *'$'* | *' '*) continue ;;
+        # A bare extension in prose ("plus `.bat` wrappers"), not a path. Real
+        # dotfiles like `.zshrc` exist, so they pass on their own merits.
+        .[a-z0-9] | .[a-z0-9][a-z0-9] | .[a-z0-9][a-z0-9][a-z0-9] | .[a-z0-9][a-z0-9][a-z0-9][a-z0-9]) continue ;;
+      esac
+      [ -e "$REPO/$token" ] || missing+=" $doc:$token"
+    done < <(grep -oE '`[.a-zA-Z0-9_/-]+`' "$REPO/$doc" |
+      tr -d '`' |
+      grep -E '^(\.|configs/|test/|windows/|powershell/|ahk/|keymaps/|docs/|osx/)' |
+      sort -u)
+  done
+  [ -z "$missing" ] || {
+    echo "documented paths that do not exist:$missing"
+    false
+  }
+}


### PR DESCRIPTION
Closes #305.

Took the issue's recommended option: **stop keeping two copies**, rather than refreshing the stale one and hoping.

## AGENTS.md

It opened by promising to mirror CLAUDE.md, then sat unchanged through the `.zshrc` split. An agent reading it was told `.zshrc` is the main config defining every alias and function, that fish parity means editing `.zshrc`, that Windows setup runs `bootstrap.ps1` to *concatenate* `windows/*.ps1` into `$PROFILE`, and that CI checks one file with `zsh -n`.

It is now a short pointer to CLAUDE.md with the reason it is a pointer. Nothing in it can go stale because nothing in it describes the repository.

## CLAUDE.md

Picks up what was only in the stale copy, or nowhere:

- **Testing** — still described just the two `run-script` directories; now lists all 8 bats suites, plus the rule that a new suite needs a `test/README.md` section and a workflow step
- the warning that sourcing `.zshrc` in a test starts background processes that hold the runner's pipes open — that has now cost two CI investigations this session
- **make.yml** — runs on Ubuntu as well as macOS, and runs `bats test/makefile.bats`
- retires the "concatenating the modules reproduces the file they replaced" claim; true at the split, not after #309/#310/#312

## test/README.md

Last `.zshrc`-era references (`_prompt_path in .zshrc`, the alias-parity description, "pulled out of `.zshrc`") and a missing section for `ssh-agent.bats`.

## test/docs.bats (new, 7 tests, wired into CI)

| Test | Catches |
| --- | --- |
| AGENTS.md sends the reader to CLAUDE.md | the pointer being deleted |
| AGENTS.md carries no second copy | the copy coming back |
| AGENTS.md does not restate CLAUDE.md's sections | ditto, by heading |
| every bats suite has a section in test/README.md | a suite added without docs |
| every bats suite is run by CI | a suite that passes locally and runs nowhere |
| CLAUDE.md lists every bats suite | the Testing list going stale again |
| repository paths named in the docs exist | **the next rename** — the generic net |

That last one scans backticked path-like tokens in `README.md`, `CLAUDE.md`, `AGENTS.md`, `test/README.md` and `docs/*.md`, skipping `$HOME` paths, globs and bare extensions (`` `.bat` `` in prose).

Each was checked by breaking what it covers:

| Break | Result |
| --- | --- |
| restore the old AGENTS.md | tests 2 and 3 fail |
| rename a suite's section heading in test/README.md | test 4 fails |
| point CLAUDE.md at `.zsh/40-theme.zsh` | test 7 fails, naming the path |

Full suite green: `docs` 7, `startup` 11, `ssh-agent` 5, `makefile` 21, `scripts` 23, `aliases` 11, `fish-config` 12, `prompt` 10.

Note tests 4–6 overlap #308's territory (CI lists suites by hand) — they turn "forgot the step" from silent into a failure, but the wildcard change itself is still that issue's.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_