### PR TITLE
ci: find the bats suites instead of listing them

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Check Zshrc syntax
+name: Lint and test
 
 on: [push, pull_request]
 
@@ -99,32 +99,28 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install bats, lsof, tmux, zsh and fish
         run: sudo apt-get update && sudo apt-get install -y bats lsof tmux zsh fish
-      - name: Run script tests
-        run: bats test/scripts.bats
-      # Keeps the shells from drifting apart again: .zshrc is the source of
-      # truth, and an alias present in both must mean the same thing.
-      - name: Run alias tests
-        run: bats test/aliases.bats
-      # zsh -n only checks syntax; these check what the prompt actually renders.
-      - name: Run prompt tests
-        run: bats test/prompt.bats
-      # .scripts on PATH and the UTF-8 locale both fail silently when missing.
-      - name: Run fish config tests
-        run: bats test/fish-config.bats
-      # A shell that prints on every start corrupts whatever reads its stdout.
-      - name: Run startup tests
-        run: bats test/startup.bats
-      # One ssh-agent per machine, not one per shell. Stubbed, so no agent is
-      # started on the runner.
-      - name: Run ssh-agent tests
-        run: bats test/ssh-agent.bats
-      # Docs drift silently; this suite also fails if a new bats suite is not
-      # documented or not given a step here.
-      - name: Run docs tests
-        run: bats test/docs.bats
+      # Every suite, found rather than listed. Naming them one step at a time
+      # meant a new test/*.bats ran nowhere until someone remembered to add a
+      # step, and a suite that never runs looks exactly like a suite that
+      # passes. What each one covers is in its own header comment, and in
+      # test/README.md.
+      #
+      # makefile.bats runs here as well as in make.yml, which is where it has
+      # to be to cover macOS. A couple of seconds, against the cost of the
+      # glob having an exception in it.
+      - name: Run bats suites
+        run: |
+          shopt -s nullglob
+          suites=(test/*.bats)
+          if [ ${#suites[@]} -eq 0 ]; then
+            echo "::error::no bats suites found under test/"
+            exit 1
+          fi
+          printf 'running: %s\n' "${suites[@]}"
+          bats "${suites[@]}"
 
   gitleaks:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## CI
 
-- **lint.yml** — checks `.zshrc` and each `.zsh/*.zsh` module with `zsh -n`, sources the whole config, then runs shellcheck, actionlint, gitleaks and the bats suites on Ubuntu
+- **lint.yml** (`Lint and test`) — checks `.zshrc` and each `.zsh/*.zsh` module with `zsh -n`, sources the whole config, then runs shellcheck, actionlint, gitleaks and every `test/*.bats` suite on Ubuntu. The bats job globs the suites rather than naming them, so a new one runs without touching the workflow
 - **make.yml** — runs `bats test/makefile.bats` and then `make` itself, on macOS and Ubuntu (the Makefile hits GNU vs BSD differences that only show up per-OS)
 - PowerShell scripts are parsed and linted with PSScriptAnalyzer on Ubuntu (`pwsh` needs no Windows runner for that); nothing exercises them on Windows
 

--- a/test/README.md
+++ b/test/README.md
@@ -18,8 +18,9 @@ or all of them:
 bats test/*.bats
 ```
 
-CI runs every suite on every push, so a suite is only useful once it is wired
-into a workflow; `docs.bats` fails if one is not.
+CI runs every suite on every push: the bats job in `lint.yml` globs
+`test/*.bats`, so a new suite is picked up with no workflow change. It still
+needs a section here — `docs.bats` fails if one is missing.
 
 ## Contents
 

--- a/test/docs.bats
+++ b/test/docs.bats
@@ -53,9 +53,23 @@ setup() {
   }
 }
 
+# Comments are stripped first: the workflow explains the glob in a comment that
+# names test/*.bats, and matching that would pass whatever the steps do.
+ci_globs_suites() {
+  local wf
+  for wf in "$REPO"/.github/workflows/*.yml; do
+    sed 's/#.*//' "$wf" | grep -q 'test/\*\.bats' && return 0
+  done
+  return 1
+}
+
 @test "every bats suite is run by CI" {
   # Adding a suite and forgetting the workflow step leaves it passing locally
-  # and never running anywhere else.
+  # and never running anywhere else. A workflow that globs test/*.bats gets
+  # that right for every suite at once, so it satisfies this on its own; the
+  # per-suite check is what applies if the steps are ever spelled out again.
+  ci_globs_suites && return 0
+
   local missing=""
   for suite in "$REPO"/test/*.bats; do
     grep -qr "bats test/$(basename "$suite")" "$REPO/.github/workflows" || missing+=" $(basename "$suite")"
@@ -64,6 +78,13 @@ setup() {
     echo "suites no workflow runs:$missing"
     false
   }
+}
+
+@test "the suites are found by CI rather than listed" {
+  # The glob is the thing that makes the check above unnecessary. Losing it
+  # silently is what this pins: a suite that never runs looks exactly like a
+  # suite that passes.
+  ci_globs_suites
 }
 
 @test "CLAUDE.md lists every bats suite" {


### PR DESCRIPTION
Closes #308.

Eight enumerated steps become one:

```yaml
- name: Run bats suites
  run: |
    shopt -s nullglob
    suites=(test/*.bats)
    if [ ${#suites[@]} -eq 0 ]; then
      echo "::error::no bats suites found under test/"
      exit 1
    fi
    printf 'running: %s\n' "${suites[@]}"
    bats "${suites[@]}"
```

A new `test/*.bats` ran nowhere until someone remembered to add a step, and **a suite that never runs looks exactly like a suite that passes**. Every suite added in this round (`startup`, `ssh-agent`, `docs`) needed that step — which is the argument for the glob. The empty-glob guard is there so a broken checkout fails loudly instead of reporting a green job that ran nothing.

`makefile.bats` now runs here as well as in `make.yml`, where it has to stay to cover macOS. Two seconds, against having an exception in the glob.

## The test that guards this

`docs.bats` had *every bats suite is run by CI*, which grepped for a per-suite step — the glob would have failed it. It now accepts the glob as proof for all suites at once, and keeps the per-suite check for the case where steps are spelled out again. A second test pins the glob itself.

**The first version of that test was wrong, and the break-check caught it.** With the glob replaced by a single suite it still passed: the grep was matching the comment *above* the step, which mentions `test/*.bats`, rather than the code. Comments are stripped before matching now:

```
not ok 5 every bats suite is run by CI
# suites no workflow runs: aliases.bats docs.bats fish-config.bats prompt.bats scripts.bats ssh-agent.bats startup.bats
not ok 6 the suites are found by CI rather than listed
```

## Also from the issue

- the bats job was on `actions/checkout@v4` while the other five were on `@v7` — aligned
- the workflow called itself `Check Zshrc syntax` while running six jobs (zsh syntax, shellcheck, actionlint, PSScriptAnalyzer, bats, gitleaks) → **`Lint and test`**. The README badge tracks `make.yml` (`Main workflow`), so it keeps working.

Verified by running the exact CI command locally — 105 tests across 8 suites, all passing:

```
running: test/aliases.bats … test/startup.bats
ok 105 the timer lives in the loader, not in a module
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01E95YBYkchuyL7vNu8qMmic)_